### PR TITLE
fix: use npm publish for reliable auth

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -75,7 +75,7 @@ for (const pkg of PACKAGES) {
     const publishArgs = ["publish", "--access", "public"];
     if (IS_CI) publishArgs.push("--provenance");
 
-    const result = spawnSync("bun", publishArgs, {
+    const result = spawnSync("npm", publishArgs, {
       cwd: join(PACKAGES_DIR, pkg),
       stdio: IS_CI ? ["pipe", "inherit", "pipe"] : "inherit",
       timeout: 120_000,


### PR DESCRIPTION
bun publish ignores .npmrc auth tokens and prompts for browser-based login, causing CI to hang. npm publish reads .npmrc correctly. No changeset needed — this is a CI script, not a published package.