### PR TITLE
fix: pass GITHUB_TOKEN to changeset status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,5 @@ jobs:
           bun-version: "1.2.19"
       - run: bun install
       - run: bunx changeset status --since=origin/main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The changeset status check in CI fails because `@changesets/changelog-github` (added in #9) needs a GitHub token to initialize. This adds `GITHUB_TOKEN` to the step so the changelog plugin can load.