### PR TITLE
ci: publish via npm trusted publishing (OIDC), drop expired NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           bun-version: "1.2.19"
 
+      # Trusted publishing (OIDC) requires a recent npm CLI (>= 11.5.1). The
+      # runner's bundled npm may be older, so upgrade it before publishing.
+      - name: Ensure npm supports trusted publishing (OIDC)
+        run: npm install -g npm@latest
+
       - run: bun install
 
       - name: Build
@@ -33,9 +38,6 @@ jobs:
 
       - name: Test
         run: bun run test
-
-      - name: Create .npmrc
-        run: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
 
       - name: Generate GitHub App token
         id: app-token
@@ -52,7 +54,6 @@ jobs:
           publish: bun run release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Releases
         if: steps.changesets.outputs.published == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,16 +68,23 @@ Releases are automated via GitHub Actions:
 
 ## Maintainer Reference
 
-### NPM_TOKEN Setup
+### npm Trusted Publishing (OIDC)
 
-1. Go to [npmjs.com](https://www.npmjs.com) → Avatar → **Access Tokens** → **Generate New Token** → **Granular Access Token**
-2. Configure the token:
-   - **Name:** `couch-kit-ci-release`
-   - **Expiration:** 1 year (set a reminder to rotate)
-   - **Packages:** Only select packages — add `@couch-kit/core`, `@couch-kit/client`, `@couch-kit/host`, `@couch-kit/cli`
-   - **Permissions:** Read and write
-3. Add the token as a GitHub repository secret named `NPM_TOKEN` (Settings → Secrets and variables → Actions)
-4. Enable "Allow GitHub Actions to create and approve pull requests" in repo Settings → Actions → General → Workflow permissions
+Packages are published from CI using [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers/) via GitHub Actions OIDC — **no long-lived `NPM_TOKEN` is required**. The release workflow has `id-token: write` permission and a recent npm CLI; npm exchanges a short-lived, workflow-scoped credential at publish time, and [provenance](https://docs.npmjs.com/generating-provenance-statements) is generated automatically.
+
+One-time setup per package (maintainer, on npmjs.com):
+
+1. Go to [npmjs.com](https://www.npmjs.com) → **Packages** → the package → **Settings** → **Trusted Publisher**
+2. Select **GitHub Actions** and configure:
+   - **Organization or user:** `faluciano`
+   - **Repository:** `react-native-couch-kit`
+   - **Workflow filename:** `release.yml`
+   - **Environment:** leave blank (the release job does not use a GitHub Environment)
+3. Repeat for every published package: `@couch-kit/core`, `@couch-kit/client`, `@couch-kit/host`, `@couch-kit/cli`, `@couch-kit/devtools`
+4. (Recommended) After verifying a publish works, set each package's **Publishing access** to **"Require two-factor authentication and disallow tokens"** for maximum security.
+5. Enable "Allow GitHub Actions to create and approve pull requests" in repo Settings → Actions → General → Workflow permissions.
+
+> The previous `NPM_TOKEN` repository secret is no longer used and can be revoked once trusted publishing is confirmed working.
 
 ### Branch Protection
 


### PR DESCRIPTION
## Why

The `couch-kit-ci-release` npm token **expired on 2026-05-16**, so the release workflow now fails with `404 on PUT` when publishing (the Version Packages merge for 0.9.1/0.8.5/1.7.8/0.3.5/0.2.5 is stuck — versions bumped on `main` but nothing reached npm).

Rather than rotate another expiring token, this migrates publishing to [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers/) via GitHub Actions **OIDC** — there is no long-lived token to expire or leak.

## Changes

- Remove the `Create .npmrc` step and the `NPM_TOKEN` env from the `changesets/action` step.
- Add a step to upgrade the runner's npm CLI to a version that supports OIDC trusted publishing (≥ 11.5.1).
- Keep `id-token: write` (already present). Provenance is now generated **automatically** by npm under trusted publishing.
- Update `CONTRIBUTING.md` with the per-package trusted-publisher setup and security recommendations.

## Required before this can publish (maintainer, one-time on npmjs.com)

For **each** of `@couch-kit/core`, `client`, `host`, `cli`, `devtools`:
Package → **Settings** → **Trusted Publisher** → **GitHub Actions**:
- Organization/user: `faluciano`
- Repository: `react-native-couch-kit`
- Workflow filename: `release.yml`
- Environment: *(blank)*

After this PR merges and trusted publishers are configured, the stuck release can be completed by re-running the Release workflow — it's idempotent (no changesets remain; `publish.ts` skips already-published versions).

CI/workflow + docs only — no `packages/` source change, so no changeset.

Refs the release failure in run 27997742936.