### PR TITLE
ci: use sudo to upgrade npm for OIDC (fix EACCES)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,9 @@ jobs:
 
       # Trusted publishing (OIDC) requires a recent npm CLI (>= 11.5.1). The
       # runner's bundled npm may be older, so upgrade it before publishing.
+      # The global npm prefix is root-owned on GitHub runners, so use sudo.
       - name: Ensure npm supports trusted publishing (OIDC)
-        run: npm install -g npm@latest
+        run: sudo npm install -g npm@latest
 
       - run: bun install
 


### PR DESCRIPTION
Follow-up to #56. The new `Ensure npm supports trusted publishing (OIDC)` step failed on the runner with:

```
npm error code EACCES
npm error Error: EACCES: permission denied, mkdir '/usr/local/share/man/man7'
```

The global npm prefix is root-owned on GitHub-hosted runners, so `npm install -g npm@latest` can't write there. This adds `sudo` to the upgrade step. The later `npm publish` still runs as the normal user (no sudo) and uses the updated global npm binary + the job's OIDC env.

CI-only change — no changeset.