### PR TITLE
ci: fix consumer dispatch (gh api has no --argjson flag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,13 +131,11 @@ jobs:
 
           for REPO in domino-party-game buzz-tv-party-game card-game-engine; do
             echo "Dispatching couch-kit-update to faluciano/$REPO"
-            gh api "repos/faluciano/$REPO/dispatches" \
-              --method POST \
-              -f event_type=couch-kit-update \
-              --argjson client_payload "$(jq -n \
-                --argjson packages "$PUBLISHED" \
-                --argjson changelog "$CHANGELOG" \
-                '{packages: $packages, changelog: $changelog}')"
+            jq -n \
+              --argjson packages "$PUBLISHED" \
+              --argjson changelog "$CHANGELOG" \
+              '{event_type: "couch-kit-update", client_payload: {packages: $packages, changelog: $changelog}}' \
+              | gh api "repos/faluciano/$REPO/dispatches" --method POST --input -
           done
 
       - name: Create breaking-change issues


### PR DESCRIPTION
## Why

The OIDC migration worked — **all 5 packages published** (0.9.1/0.8.5/1.7.8/0.3.5/0.2.5) and GitHub Releases were created. But the **Dispatch consumer updates** step failed:

```
unknown flag: --argjson
```

`--argjson` is a **jq** flag, not a `gh api` flag, so the `repository_dispatch` to each consumer repo (domino, buzz, card-game-engine) never fired.

## Fix

Build the full dispatch body with `jq` and pipe it to `gh api --input -`:

```bash
jq -n --argjson packages "$PUBLISHED" --argjson changelog "$CHANGELOG" \
  '{event_type: "couch-kit-update", client_payload: {packages: $packages, changelog: $changelog}}' \
  | gh api "repos/faluciano/$REPO/dispatches" --method POST --input -
```

The payload shape (`client_payload.packages` + `client_payload.changelog`) matches what `scripts/templates/consumer-update-workflow.yml` consumes.

## Note

This is a pre-existing bug, independent of the OIDC change. The 0.9.1 release is already on npm; this only restores the consumer auto-update notifications for future (and can be manually dispatched for 0.9.1 if desired).

CI-only — no changeset.