### PR TITLE
fix(host): deprecate no-op WebSocketConfig options (#51)

### DIFF
--- a/.changeset/deprecate-websocket-noop-options.md
+++ b/.changeset/deprecate-websocket-noop-options.md
@@ -1,0 +1,5 @@
+---
+"@couch-kit/host": patch
+---
+
+Mark the unused `WebSocketConfig` options (`maxFrameSize`, `keepaliveInterval`, `keepaliveTimeout`) as `@deprecated`. These have no effect — the nitro-http WebSocket transport does not expose these knobs, and the server only honors `port` and `debug`. The deprecated fields are retained for backward compatibility and will be removed in a future major release. Application-level heartbeats continue to be handled by the host PING/PONG protocol.

--- a/packages/host/src/websocket.ts
+++ b/packages/host/src/websocket.ts
@@ -16,11 +16,24 @@ import { generateId, DEFAULT_WS_PATH } from "@couch-kit/core";
 export interface WebSocketConfig {
   port: number;
   debug?: boolean;
-  /** Maximum allowed frame payload size in bytes (default: 1 MB). */
+  /**
+   * @deprecated No effect. The underlying nitro-http WebSocket transport
+   * manages frame sizing internally and this value is never read. This field
+   * will be removed in a future major release. Do not set it.
+   */
   maxFrameSize?: number;
-  /** Interval (ms) between server-side keepalive pings (default: 30s). 0 disables. */
+  /**
+   * @deprecated No effect. The nitro-http WebSocket transport does not expose
+   * server-side keepalive ping configuration, so this value is never read.
+   * Application-level heartbeats are handled by the host PING/PONG protocol.
+   * This field will be removed in a future major release. Do not set it.
+   */
   keepaliveInterval?: number;
-  /** Timeout (ms) to wait for a pong after a keepalive ping (default: 10s). */
+  /**
+   * @deprecated No effect. The nitro-http WebSocket transport does not expose
+   * keepalive pong-timeout configuration, so this value is never read. This
+   * field will be removed in a future major release. Do not set it.
+   */
   keepaliveTimeout?: number;
 }
 
@@ -48,9 +61,10 @@ export class GameWebSocketServer extends EventEmitter<WebSocketServerEvents> {
     super();
     this.port = config.port;
     this.debug = !!config.debug;
-    // Note: maxFrameSize, keepaliveInterval, and keepaliveTimeout are not directly
-    // configurable in nitro-http WebSocket plugin, but the underlying implementation
-    // handles these concerns automatically.
+    // Only `port` and `debug` are honored. `maxFrameSize`, `keepaliveInterval`,
+    // and `keepaliveTimeout` are deprecated no-ops: the nitro-http WebSocket
+    // transport does not expose these knobs, so they are intentionally ignored
+    // (see the @deprecated tags on WebSocketConfig).
   }
 
   private log(...args: unknown[]) {


### PR DESCRIPTION
Closes #51.

## Problem

`WebSocketConfig` (a public, exported type from `@couch-kit/host`) advertises three options that are **silently ignored**:

```ts
maxFrameSize?: number;       // claimed 'default: 1 MB'
keepaliveInterval?: number;  // claimed 'default: 30s'
keepaliveTimeout?: number;   // claimed 'default: 10s'
```

The `GameWebSocketServer` constructor only reads `port` and `debug`. The underlying `react-native-nitro-http-server` WebSocket transport does not expose frame-size or server-side keepalive ping/pong configuration, so these values are never used. The only internal caller (`provider.tsx`) passes just `{ port, debug }`.

## Approach

These fields are part of the **public API** (`websocket.ts` is re-exported via `export *`), so removing them outright would be a breaking type change → a major bump just to drop dead options. Instead, this PR **deprecates** them:

- Added `@deprecated` JSDoc to all three fields with an honest explanation that they have no effect and will be removed in a future major. Consumers get IDE strikethrough + guidance; nothing breaks.
- Replaced the misleading "defaults" doc comments (they implied the options worked).
- Clarified the constructor comment to state only `port`/`debug` are honored.

→ **patch** changeset for `@couch-kit/host`.

## Historical note (not addressed here)

CHANGELOG history shows a past "Add WebSocket `maxFrameSize` enforcement to prevent OOM attacks" entry — enforcement that appears to have been lost during the nitro-http migration. Re-introducing a real frame/message-size guard is a **separate feature** (would need nitro-http mount-based `max_message_size` wiring + tests) and is intentionally out of scope for this deprecation. Happy to file a follow-up if you want it tracked.

## Verification

`build`, `typecheck`, `test`, `lint` all pass. No source outside `websocket.ts` references the deprecated fields.

Closes #51