### PR TITLE
fix(devtools): make @couch-kit/client a peerDependency (#52)

### DIFF
--- a/.changeset/devtools-client-peer-dependency.md
+++ b/.changeset/devtools-client-peer-dependency.md
@@ -1,0 +1,5 @@
+---
+"@couch-kit/devtools": patch
+---
+
+Declare `@couch-kit/client` as a `peerDependency` (with a workspace `devDependency` for local builds) instead of a runtime `dependency`. `devtools` only uses a type from the client (`DebugPanelData`) and is always used alongside an existing `@couch-kit/client` in the consumer's web controller, so this prevents a second copy of the client (and transitively React) from being installed/bundled. The published runtime bundle already externalizes `react` and `@couch-kit/client`, so there is no behavior change at runtime.

--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
     },
     "packages/client": {
       "name": "@couch-kit/client",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "dependencies": {
         "@couch-kit/core": "workspace:*",
       },
@@ -56,23 +56,22 @@
     },
     "packages/devtools": {
       "name": "@couch-kit/devtools",
-      "version": "0.2.5",
-      "dependencies": {
-        "@couch-kit/client": "workspace:*",
-      },
+      "version": "0.2.6",
       "devDependencies": {
+        "@couch-kit/client": "workspace:*",
         "@couch-kit/core": "workspace:*",
         "@types/react": "^19.1.1",
         "react": "^18.2.0",
         "typescript": "^5.4.0",
       },
       "peerDependencies": {
+        "@couch-kit/client": "workspace:*",
         "react": ">=18.0.0",
       },
     },
     "packages/host": {
       "name": "@couch-kit/host",
-      "version": "1.7.8",
+      "version": "1.7.9",
       "dependencies": {
         "@couch-kit/core": "workspace:*",
         "buffer": "^6.0.3",
@@ -1677,8 +1676,6 @@
     "@changesets/apply-release-plan/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
     "@changesets/write/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
-
-    "@couch-kit/devtools/@types/react": ["@types/react@19.2.10", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw=="],
 
     "@couch-kit/host/@types/react": ["@types/react@19.2.10", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw=="],
 

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -26,16 +26,16 @@
     "README.md",
     "CHANGELOG.md"
   ],
-  "dependencies": {
-    "@couch-kit/client": "workspace:*"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "@couch-kit/client": "workspace:*",
     "@couch-kit/core": "workspace:*",
     "@types/react": "^19.1.1",
     "react": "^18.2.0",
     "typescript": "^5.4.0"
   },
   "peerDependencies": {
+    "@couch-kit/client": "workspace:*",
     "react": ">=18.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
Closes #52.

## Problem

`@couch-kit/devtools` declared `@couch-kit/client` as a regular runtime `dependency`, but it only imports a **type** from it:

```ts
import type { DebugPanelData } from "@couch-kit/client";
```

Since the debug overlay always renders inside a web controller that already depends on `@couch-kit/client`, a regular dependency risks installing/bundling a **second copy** of the client (and transitively React) in consumer apps — the same reason `react`/`react-native` are already peers.

## Change

- Move `@couch-kit/client` from `dependencies` → `peerDependencies` (kept as `workspace:*`), mirroring the existing `react` peer.
- Add `@couch-kit/client: workspace:*` to `devDependencies` for local builds/typecheck.
- `dependencies` is now empty (`devtools` has no other runtime deps).

## Verification (acceptance criteria)

- [x] **Dependency relationship reviewed/corrected** — now a peer + workspace devDep.
- [x] **No duplicate client/React in published output** — the runtime bundle (`dist/index.js`) contains **zero** `@couch-kit/client`/`@couch-kit/core` references (the type import is erased) and imports `react` as external. The `.d.ts` still references the client type, which is exactly why it must be a peer (consumer provides it).
- [x] **`workspace:*` resolution still handled by the publish script** — `scripts/publish.ts` resolves `workspace:*` in `dependencies`, `peerDependencies`, and `devDependencies`.

`build`, `typecheck`, `test`, `lint` all pass. Patch changeset added for `@couch-kit/devtools`.

## Note

Realistic consumers (which use `@couch-kit/client` + `devtools` together) are unaffected. A hypothetical consumer that installed `devtools` *without* the client would now see a peer-dependency notice — correct, since the overlay renders client-produced debug data.

Closes #52