### PR TITLE
ci(release): retry changeset version on transient GitHub API errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "typecheck": "bun run --filter '@couch-kit/core' typecheck && bun run --filter '*' typecheck",
     "clean": "bun run --filter '*' clean",
     "changeset": "changeset",
-    "version": "changeset version",
+    "version": "bun run scripts/version.ts",
     "release": "bun run scripts/publish.ts",
     "lint:changesets": "bun run scripts/lint-changeset-headers.ts",
     "docs": "typedoc",

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -1,0 +1,67 @@
+import { spawnSync } from "child_process";
+
+/**
+ * Runs `changeset version` with retries.
+ *
+ * The `@changesets/changelog-github` plugin calls the GitHub GraphQL API to
+ * build changelog entries, and that request intermittently fails on CI with
+ * errors like:
+ *
+ *   error Failed to parse data from GitHub
+ *   error Invalid response body while trying to fetch
+ *         https://api.github.com/graphql: Premature close
+ *
+ * When this happens changesets explicitly "escapes applying the changesets,
+ * and no files should have been affected", so the command is safe to retry.
+ * Without a retry, a single transient API blip fails the whole release run and
+ * requires a manual re-run.
+ */
+const MAX_ATTEMPTS = 5;
+const BASE_DELAY_MS = 5_000;
+
+const TRANSIENT_PATTERN =
+  /Failed to parse data from GitHub|Premature close|fetch failed|ECONNRESET|ETIMEDOUT|socket hang up|terminated/i;
+
+function sleep(ms: number): void {
+  // Synchronous, non-busy-waiting sleep so this stays a simple, dependency-free
+  // script that blocks between retries without spinning a CPU core.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function runChangesetVersion(): { code: number; stderr: string } {
+  const result = spawnSync("changeset", ["version"], {
+    stdio: ["inherit", "inherit", "pipe"],
+    encoding: "utf-8",
+    shell: process.platform === "win32",
+  });
+  const stderr = result.stderr ?? "";
+  if (stderr) process.stderr.write(stderr);
+  return { code: result.status ?? 1, stderr };
+}
+
+for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+  const { code, stderr } = runChangesetVersion();
+
+  if (code === 0) {
+    process.exit(0);
+  }
+
+  const isTransient = TRANSIENT_PATTERN.test(stderr);
+  const isLastAttempt = attempt === MAX_ATTEMPTS;
+
+  if (!isTransient || isLastAttempt) {
+    console.error(
+      `\n✖ \`changeset version\` failed (attempt ${attempt}/${MAX_ATTEMPTS}) ` +
+        `with exit code ${code}.` +
+        (isTransient ? " Giving up after exhausting retries." : ""),
+    );
+    process.exit(code);
+  }
+
+  const delay = BASE_DELAY_MS * attempt;
+  console.warn(
+    `\n⚠️  Transient GitHub API error during \`changeset version\` ` +
+      `(attempt ${attempt}/${MAX_ATTEMPTS}). Retrying in ${delay / 1000}s...`,
+  );
+  sleep(delay);
+}


### PR DESCRIPTION
## Problem

The release workflow has failed **repeatedly** during `bun run version` with a transient GitHub API error:

```
The following error was encountered while generating changelog entries
We have escaped applying the changesets, and no files should have been affected
🦋  error Failed to parse data from GitHub
🦋  error Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
```

`@changesets/changelog-github` calls the GitHub GraphQL API (via `@changesets/get-github-info`, `node-fetch@2`) to build changelog entries, and that request intermittently drops the connection on GitHub-hosted runners. A single blip fails the whole release run and forces a manual re-run — it hit **~4 release runs** across the recent dependency PRs (#62/#64/#66), each needing a manual rerun before publishing succeeded.

Crucially, changesets prints _"We have escaped applying the changesets, and no files should have been affected"_ — so the command is **safe to retry**.

## Fix

Add **`scripts/version.ts`**, a tiny dependency-free wrapper that runs `changeset version` with up to **5 attempts** and increasing backoff. It:

- retries **only** on known-transient network errors (`Failed to parse data from GitHub`, `Premature close`, `fetch failed`, `ECONNRESET`, etc.),
- surfaces real/config failures **immediately** (no masking),
- blocks between retries with `Atomics.wait` (no CPU busy-wait).

The root `version` script now points at it, so `changesets/action@v1` (`version: bun run version`) picks it up transparently.

## Verification

- Smoke-tested locally: `bun run version` runs `changeset version`, exits 0, touches no unexpected files.
- CI/tooling only — no `packages/` source changed, so **no changeset** is required (the `changesets` CI job passes with none).

## Notes

Mirrors the existing already-published-error handling in `scripts/publish.ts`. If the flake ever becomes persistent rather than transient, the wrapper still fails after exhausting retries so it won't hide a genuine outage.