### PR TITLE
test(client): extract and unit-test connection logic

### DIFF
--- a/.changeset/client-connection-extraction.md
+++ b/.changeset/client-connection-extraction.md
@@ -1,0 +1,8 @@
+---
+"@couch-kit/client": patch
+---
+
+Extract the client's connection logic (WebSocket URL resolution, reconnect
+backoff, session-secret recovery, and host-message interpretation) into a
+framework-free `connection` module with full unit test coverage. No behavior
+change; these pure helpers are now exported for reuse and testing.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -2,12 +2,9 @@ import { useState, useEffect, useRef, useCallback, useReducer } from "react";
 import {
   MessageTypes,
   InternalActionTypes,
-  DEFAULT_WS_PORT_OFFSET,
-  DEFAULT_WS_PATH,
   DEFAULT_MAX_RETRIES,
   DEFAULT_BASE_DELAY,
   DEFAULT_MAX_DELAY,
-  generateId,
   createGameReducer,
   type HostMessage,
   type IGameState,
@@ -15,6 +12,13 @@ import {
   type InternalAction,
 } from "@couch-kit/core";
 import { useServerTime } from "./time-sync";
+import {
+  resolveWebSocketUrl,
+  computeBackoffDelay,
+  shouldReconnect,
+  resolveSessionSecret,
+  interpretHostMessage,
+} from "./connection";
 
 export interface ClientConfig<S extends IGameState, A extends IAction> {
   url?: string; // Full WebSocket URL (overrides auto-detection)
@@ -100,15 +104,10 @@ export function useGameClient<S extends IGameState, A extends IAction>(
     // so derive the WebSocket URL from window.location.
     // Convention: WS port = HTTP port + 2 (e.g., HTTP 8080 -> WS 8082)
     // Port + 1 is skipped to avoid conflicts with Metro bundler (which uses 8081)
-    let wsUrl = cfg.url;
-
-    if (!wsUrl && typeof window !== "undefined") {
-      const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-      const host = window.location.hostname;
-      const httpPort = parseInt(window.location.port, 10) || 80;
-      const wsPort = cfg.wsPort || httpPort + DEFAULT_WS_PORT_OFFSET;
-      wsUrl = `${protocol}//${host}:${wsPort}${DEFAULT_WS_PATH}`;
-    }
+    const wsUrl = resolveWebSocketUrl(
+      { url: cfg.url, wsPort: cfg.wsPort },
+      typeof window !== "undefined" ? window.location : null,
+    );
 
     if (!wsUrl) return;
 
@@ -125,19 +124,9 @@ export function useGameClient<S extends IGameState, A extends IAction>(
       currentCfg.onConnect?.();
 
       // Session Recovery Logic -- use cryptographically random secrets
-      let secret: string;
-      try {
-        const stored = localStorage.getItem("ck_secret");
-        if (stored) {
-          secret = stored;
-        } else {
-          secret = generateId();
-          localStorage.setItem("ck_secret", secret);
-        }
-      } catch {
-        // localStorage unavailable (Safari private browsing, restrictive WebViews, etc.)
-        secret = generateId();
-      }
+      const secret = resolveSessionSecret(
+        typeof localStorage !== "undefined" ? localStorage : null,
+      );
 
       // Join with secret
       try {
@@ -158,41 +147,30 @@ export function useGameClient<S extends IGameState, A extends IAction>(
     };
 
     ws.onmessage = (event) => {
+      let msg: HostMessage;
       try {
-        const msg = JSON.parse(event.data) as HostMessage;
+        msg = JSON.parse(event.data) as HostMessage;
+      } catch (e) {
+        console.error("Failed to parse message", e);
+        return;
+      }
 
-        switch (msg.type) {
-          case MessageTypes.WELCOME:
-            setPlayerId(msg.payload.playerId);
-            // Hydrate state from server (Single Source of Truth)
-            dispatchLocal({
-              type: InternalActionTypes.HYDRATE,
-              payload: msg.payload.state as S,
-            } as InternalAction<S>);
+      for (const effect of interpretHostMessage<S>(msg)) {
+        switch (effect.kind) {
+          case "setPlayerId":
+            setPlayerId(effect.playerId);
             break;
-
-          case MessageTypes.STATE_UPDATE:
+          case "hydrate":
             // Full state replacement from the host's authoritative state.
             dispatchLocal({
               type: InternalActionTypes.HYDRATE,
-              payload: msg.payload.newState as S,
+              payload: effect.state,
             } as InternalAction<S>);
             break;
-
-          case MessageTypes.PONG:
-            handlePongRef.current(msg.payload);
-            break;
-
-          case MessageTypes.RECONNECTED:
-            setPlayerId(msg.payload.playerId);
-            dispatchLocal({
-              type: InternalActionTypes.HYDRATE,
-              payload: msg.payload.state as S,
-            } as InternalAction<S>);
+          case "pong":
+            handlePongRef.current(effect.payload);
             break;
         }
-      } catch (e) {
-        console.error("Failed to parse message", e);
       }
     };
 
@@ -201,25 +179,31 @@ export function useGameClient<S extends IGameState, A extends IAction>(
       configRef.current.onDisconnect?.();
 
       // Don't reconnect if the close was intentional or if the server
-      // sent a policy/unexpected error close code
-      if (intentionalClose.current) return;
-      if (event.code === 1008 || event.code === 1011) return;
+      // sent a policy/unexpected error close code, or once retries are exhausted.
+      if (
+        !shouldReconnect({
+          intentionalClose: intentionalClose.current,
+          closeCode: event.code,
+          attempts: reconnectAttempts.current,
+          maxRetries,
+        })
+      )
+        return;
 
       // Exponential backoff reconnection
-      if (reconnectAttempts.current < maxRetries) {
-        const delay = Math.min(
-          baseDelay * Math.pow(2, reconnectAttempts.current),
-          maxDelay,
-        );
-        reconnectAttempts.current++;
+      const delay = computeBackoffDelay(
+        reconnectAttempts.current,
+        baseDelay,
+        maxDelay,
+      );
+      reconnectAttempts.current++;
 
-        if (configRef.current.debug)
-          console.log(`[GameClient] Reconnecting in ${delay}ms...`);
+      if (configRef.current.debug)
+        console.log(`[GameClient] Reconnecting in ${delay}ms...`);
 
-        reconnectTimer.current = setTimeout(() => {
-          connect();
-        }, delay);
-      }
+      reconnectTimer.current = setTimeout(() => {
+        connect();
+      }, delay);
     };
 
     ws.onerror = (e) => {

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -1,0 +1,172 @@
+import {
+  MessageTypes,
+  DEFAULT_WS_PORT_OFFSET,
+  DEFAULT_WS_PATH,
+  generateId,
+  type HostMessage,
+} from "@couch-kit/core";
+
+/**
+ * Framework-free connection logic for the web game client.
+ *
+ * These helpers contain the pure, side-effect-free decision logic that the
+ * `useGameClient` hook relies on (URL derivation, reconnect/backoff scheduling,
+ * session-secret recovery, and host-message routing). They are kept separate
+ * from the React hook so the behavior can be unit-tested without a WebSocket or
+ * a DOM.
+ */
+
+/** localStorage key under which the session-recovery secret is persisted. */
+export const SESSION_SECRET_KEY = "ck_secret";
+
+/** The subset of `WebSocket` close codes that must NOT trigger a reconnect. */
+const NON_RECOVERABLE_CLOSE_CODES = new Set<number>([
+  1008, // policy violation (e.g. INVALID_SECRET / FORBIDDEN_ACTION)
+  1011, // internal server error
+]);
+
+/** Connection options relevant to deriving the WebSocket URL. */
+export interface UrlResolutionConfig {
+  /** Full WebSocket URL. When set, it is used verbatim. */
+  url?: string;
+  /** WebSocket port override. Defaults to the page's HTTP port + offset. */
+  wsPort?: number;
+}
+
+/** The minimal shape of `window.location` needed to derive a WS URL. */
+export interface LocationLike {
+  protocol: string;
+  hostname: string;
+  port: string;
+}
+
+/**
+ * Resolve the WebSocket URL to connect to.
+ *
+ * If `config.url` is provided it is returned as-is. Otherwise the URL is
+ * derived from the current page location using the convention
+ * `WS port = HTTP port + DEFAULT_WS_PORT_OFFSET` (HTTP 8080 -> WS 8082; port+1
+ * is skipped to avoid Metro's 8081). Returns `null` when no URL can be
+ * determined (no explicit URL and no location available).
+ */
+export function resolveWebSocketUrl(
+  config: UrlResolutionConfig,
+  location: LocationLike | null | undefined,
+): string | null {
+  if (config.url) return config.url;
+  if (!location) return null;
+
+  const protocol = location.protocol === "https:" ? "wss:" : "ws:";
+  const host = location.hostname;
+  const httpPort = parseInt(location.port, 10) || 80;
+  const wsPort = config.wsPort || httpPort + DEFAULT_WS_PORT_OFFSET;
+
+  return `${protocol}//${host}:${wsPort}${DEFAULT_WS_PATH}`;
+}
+
+/**
+ * Compute the exponential-backoff delay (ms) for a reconnection attempt.
+ *
+ * `delay = min(baseDelay * 2^attempt, maxDelay)`, where `attempt` is the
+ * zero-based count of reconnects already made.
+ */
+export function computeBackoffDelay(
+  attempt: number,
+  baseDelay: number,
+  maxDelay: number,
+): number {
+  return Math.min(baseDelay * Math.pow(2, attempt), maxDelay);
+}
+
+/** Inputs to the {@link shouldReconnect} decision. */
+export interface ReconnectDecision {
+  /** Whether the disconnect was initiated locally (manual disconnect/unmount). */
+  intentionalClose: boolean;
+  /** The WebSocket close code from the `close` event. */
+  closeCode: number;
+  /** Number of reconnection attempts already made. */
+  attempts: number;
+  /** Maximum number of reconnection attempts permitted. */
+  maxRetries: number;
+}
+
+/**
+ * Decide whether the client should attempt an automatic reconnect.
+ *
+ * Returns `false` for intentional closes, for non-recoverable server close
+ * codes (1008 policy / 1011 internal error), or once the attempt budget is
+ * exhausted; otherwise `true`.
+ */
+export function shouldReconnect(decision: ReconnectDecision): boolean {
+  if (decision.intentionalClose) return false;
+  if (NON_RECOVERABLE_CLOSE_CODES.has(decision.closeCode)) return false;
+  return decision.attempts < decision.maxRetries;
+}
+
+/** The minimal storage surface used for session-secret recovery. */
+export type SecretStorage = Pick<Storage, "getItem" | "setItem">;
+
+/**
+ * Resolve the session-recovery secret.
+ *
+ * Reuses an existing secret from storage when present, otherwise generates a
+ * new one and persists it. When storage is unavailable or throws (e.g. Safari
+ * private browsing, restrictive WebViews), a fresh secret is generated without
+ * persistence so a JOIN can still proceed.
+ */
+export function resolveSessionSecret(
+  storage: SecretStorage | null | undefined,
+  generate: () => string = generateId,
+): string {
+  try {
+    if (!storage) return generate();
+    const stored = storage.getItem(SESSION_SECRET_KEY);
+    if (stored) return stored;
+    const secret = generate();
+    storage.setItem(SESSION_SECRET_KEY, secret);
+    return secret;
+  } catch {
+    return generate();
+  }
+}
+
+/**
+ * A side-effect descriptor produced by {@link interpretHostMessage}. The client
+ * hook executes these against React state so the routing logic itself stays
+ * pure and testable.
+ */
+export type HostMessageEffect<S> =
+  | { kind: "setPlayerId"; playerId: string }
+  | { kind: "hydrate"; state: S }
+  | { kind: "pong"; payload: PongPayload };
+
+/** Payload of a `PONG` host message. */
+export type PongPayload = Extract<HostMessage, { type: "PONG" }>["payload"];
+
+/**
+ * Translate a parsed host message into the ordered list of effects the client
+ * should apply. Unknown/irrelevant message types (e.g. `ERROR`) yield no
+ * effects.
+ */
+export function interpretHostMessage<S>(
+  msg: HostMessage,
+): HostMessageEffect<S>[] {
+  switch (msg.type) {
+    case MessageTypes.WELCOME:
+      return [
+        { kind: "setPlayerId", playerId: msg.payload.playerId },
+        { kind: "hydrate", state: msg.payload.state as S },
+      ];
+    case MessageTypes.STATE_UPDATE:
+      return [{ kind: "hydrate", state: msg.payload.newState as S }];
+    case MessageTypes.PONG:
+      return [{ kind: "pong", payload: msg.payload }];
+    case MessageTypes.RECONNECTED:
+      return [
+        { kind: "setPlayerId", playerId: msg.payload.playerId },
+        { kind: "hydrate", state: msg.payload.state as S },
+      ];
+    default:
+      return [];
+  }
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./client";
+export * from "./connection";
 export * from "./time-sync";
 export * from "./assets";
 export * from "./debug-panel";

--- a/packages/client/tests/connection.test.ts
+++ b/packages/client/tests/connection.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, test } from "bun:test";
+import {
+  resolveWebSocketUrl,
+  computeBackoffDelay,
+  shouldReconnect,
+  resolveSessionSecret,
+  interpretHostMessage,
+  SESSION_SECRET_KEY,
+  type SecretStorage,
+  type HostMessageEffect,
+} from "../src/connection";
+import {
+  DEFAULT_BASE_DELAY,
+  DEFAULT_MAX_DELAY,
+  DEFAULT_MAX_RETRIES,
+  type HostMessage,
+} from "@couch-kit/core";
+
+describe("resolveWebSocketUrl", () => {
+  test("returns an explicit url verbatim, ignoring location", () => {
+    const url = resolveWebSocketUrl(
+      { url: "ws://example.test:9999/ws" },
+      { protocol: "https:", hostname: "ignored", port: "443" },
+    );
+    expect(url).toBe("ws://example.test:9999/ws");
+  });
+
+  test("derives ws:// from an http page using HTTP port + offset", () => {
+    const url = resolveWebSocketUrl(
+      {},
+      { protocol: "http:", hostname: "192.168.1.10", port: "8080" },
+    );
+    // WS port = 8080 + 2 = 8082
+    expect(url).toBe("ws://192.168.1.10:8082/ws");
+  });
+
+  test("derives wss:// for https pages", () => {
+    const url = resolveWebSocketUrl(
+      {},
+      { protocol: "https:", hostname: "host.local", port: "8080" },
+    );
+    expect(url).toBe("wss://host.local:8082/ws");
+  });
+
+  test("honors an explicit wsPort override instead of deriving from location", () => {
+    const url = resolveWebSocketUrl(
+      { wsPort: 1234 },
+      { protocol: "http:", hostname: "host.local", port: "8080" },
+    );
+    expect(url).toBe("ws://host.local:1234/ws");
+  });
+
+  test("falls back to port 80 when the page port is empty", () => {
+    const url = resolveWebSocketUrl(
+      {},
+      { protocol: "http:", hostname: "host.local", port: "" },
+    );
+    // 80 + 2 = 82
+    expect(url).toBe("ws://host.local:82/ws");
+  });
+
+  test("returns null when there is no url and no location", () => {
+    expect(resolveWebSocketUrl({}, null)).toBeNull();
+    expect(resolveWebSocketUrl({}, undefined)).toBeNull();
+  });
+});
+
+describe("computeBackoffDelay", () => {
+  test("grows exponentially from the base delay", () => {
+    expect(computeBackoffDelay(0, 1000, 10000)).toBe(1000);
+    expect(computeBackoffDelay(1, 1000, 10000)).toBe(2000);
+    expect(computeBackoffDelay(2, 1000, 10000)).toBe(4000);
+    expect(computeBackoffDelay(3, 1000, 10000)).toBe(8000);
+  });
+
+  test("caps at maxDelay", () => {
+    expect(computeBackoffDelay(4, 1000, 10000)).toBe(10000);
+    expect(computeBackoffDelay(10, 1000, 10000)).toBe(10000);
+  });
+
+  test("works with the package default delays", () => {
+    expect(computeBackoffDelay(0, DEFAULT_BASE_DELAY, DEFAULT_MAX_DELAY)).toBe(
+      1000,
+    );
+    expect(computeBackoffDelay(5, DEFAULT_BASE_DELAY, DEFAULT_MAX_DELAY)).toBe(
+      DEFAULT_MAX_DELAY,
+    );
+  });
+});
+
+describe("shouldReconnect", () => {
+  const base = { intentionalClose: false, closeCode: 1006, attempts: 0, maxRetries: 5 };
+
+  test("reconnects on an abnormal close with attempts remaining", () => {
+    expect(shouldReconnect(base)).toBe(true);
+  });
+
+  test("never reconnects after an intentional close", () => {
+    expect(shouldReconnect({ ...base, intentionalClose: true })).toBe(false);
+  });
+
+  test("does not reconnect on policy (1008) or internal-error (1011) closes", () => {
+    expect(shouldReconnect({ ...base, closeCode: 1008 })).toBe(false);
+    expect(shouldReconnect({ ...base, closeCode: 1011 })).toBe(false);
+  });
+
+  test("stops once the retry budget is exhausted", () => {
+    expect(shouldReconnect({ ...base, attempts: 4, maxRetries: 5 })).toBe(true);
+    expect(shouldReconnect({ ...base, attempts: 5, maxRetries: 5 })).toBe(false);
+    expect(shouldReconnect({ ...base, attempts: 6, maxRetries: 5 })).toBe(false);
+  });
+
+  test("intentional close takes priority over a recoverable code/attempts", () => {
+    expect(
+      shouldReconnect({
+        intentionalClose: true,
+        closeCode: 1006,
+        attempts: 0,
+        maxRetries: DEFAULT_MAX_RETRIES,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveSessionSecret", () => {
+  function makeStorage(initial: Record<string, string> = {}): SecretStorage & {
+    store: Record<string, string>;
+  } {
+    const store = { ...initial };
+    return {
+      store,
+      getItem: (k: string) => (k in store ? store[k] : null),
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+    };
+  }
+
+  test("reuses an existing persisted secret", () => {
+    const storage = makeStorage({ [SESSION_SECRET_KEY]: "existing-secret" });
+    const secret = resolveSessionSecret(storage, () => "generated");
+    expect(secret).toBe("existing-secret");
+  });
+
+  test("generates and persists a new secret when none exists", () => {
+    const storage = makeStorage();
+    const secret = resolveSessionSecret(storage, () => "generated");
+    expect(secret).toBe("generated");
+    expect(storage.store[SESSION_SECRET_KEY]).toBe("generated");
+  });
+
+  test("generates a fresh secret without persisting when storage is null", () => {
+    const secret = resolveSessionSecret(null, () => "generated");
+    expect(secret).toBe("generated");
+  });
+
+  test("generates a fresh secret when getItem throws (e.g. private mode)", () => {
+    const throwing: SecretStorage = {
+      getItem: () => {
+        throw new Error("SecurityError");
+      },
+      setItem: () => {},
+    };
+    expect(resolveSessionSecret(throwing, () => "fallback")).toBe("fallback");
+  });
+
+  test("generates a fresh secret when setItem throws", () => {
+    const throwing: SecretStorage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("QuotaExceededError");
+      },
+    };
+    expect(resolveSessionSecret(throwing, () => "fallback")).toBe("fallback");
+  });
+
+  test("defaults to generateId when no generator is supplied", () => {
+    const storage = makeStorage();
+    const secret = resolveSessionSecret(storage);
+    expect(typeof secret).toBe("string");
+    expect(secret.length).toBeGreaterThan(0);
+    // and it is persisted for reuse
+    expect(storage.store[SESSION_SECRET_KEY]).toBe(secret);
+  });
+});
+
+describe("interpretHostMessage", () => {
+  test("WELCOME sets the player id then hydrates state, in order", () => {
+    const msg: HostMessage = {
+      type: "WELCOME",
+      payload: { playerId: "p1", state: { score: 1 }, serverTime: 123 },
+    };
+    const effects = interpretHostMessage<{ score: number }>(msg);
+    expect(effects).toEqual([
+      { kind: "setPlayerId", playerId: "p1" },
+      { kind: "hydrate", state: { score: 1 } },
+    ]);
+  });
+
+  test("STATE_UPDATE hydrates from newState", () => {
+    const msg: HostMessage = {
+      type: "STATE_UPDATE",
+      payload: { newState: { score: 7 }, timestamp: 999 },
+    };
+    const effects = interpretHostMessage<{ score: number }>(msg);
+    expect(effects).toEqual([{ kind: "hydrate", state: { score: 7 } }]);
+  });
+
+  test("RECONNECTED sets the player id then hydrates state", () => {
+    const msg: HostMessage = {
+      type: "RECONNECTED",
+      payload: { playerId: "p9", state: { score: 3 } },
+    };
+    const effects = interpretHostMessage<{ score: number }>(msg);
+    expect(effects).toEqual([
+      { kind: "setPlayerId", playerId: "p9" },
+      { kind: "hydrate", state: { score: 3 } },
+    ]);
+  });
+
+  test("PONG forwards the time-sync payload", () => {
+    const payload = { id: "ping-1", origTimestamp: 10, serverTime: 20 };
+    const msg: HostMessage = { type: "PONG", payload };
+    const effects = interpretHostMessage(msg);
+    expect(effects).toEqual([{ kind: "pong", payload }]);
+  });
+
+  test("ERROR (and other non-routed messages) produce no effects", () => {
+    const msg: HostMessage = {
+      type: "ERROR",
+      payload: { code: "INVALID_SECRET", message: "nope" },
+    };
+    const effects: HostMessageEffect<unknown>[] = interpretHostMessage(msg);
+    expect(effects).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #50.

Extracts the testable connection logic out of the `useGameClient` hook into a new framework-free `packages/client/src/connection.ts` module, and adds unit tests for it. **No behavior change** — `client.ts` now delegates to these pure helpers.

### Extracted pure helpers (`connection.ts`)
- `resolveWebSocketUrl(config, location)` — explicit URL vs. derived ws/wss + HTTP-port offset, null-location safe.
- `computeBackoffDelay(attempt, baseDelay, maxDelay)` — exponential backoff with cap.
- `shouldReconnect({ intentionalClose, closeCode, attempts, maxRetries })` — reconnect decision (intentional close, policy/error codes 1008/1011, retry budget).
- `resolveSessionSecret(storage, generate?)` — reuse-or-generate secret, resilient to throwing/absent storage.
- `interpretHostMessage(msg)` — maps a `HostMessage` to an ordered list of effects.

These are exported from the package index, mirroring the existing `time-sync` pure-helper convention.

### Tests
`packages/client/tests/connection.test.ts` — 24 cases covering URL derivation, backoff growth/cap, reconnect rules, secret recovery edge cases, and message→effect mapping.

### Changeset
Patch bump for `@couch-kit/client` (devtools bumps as a dependent).

## Verification
`bun run build && bun run typecheck && bun run test && bun run lint` all green (only the pre-existing unrelated `core/reducer.ts` warning remains).