### PR TITLE
refactor(host): extract & unit-test runtime logic from provider

### DIFF
--- a/.changeset/extract-host-runtime-logic.md
+++ b/.changeset/extract-host-runtime-logic.md
@@ -1,0 +1,5 @@
+---
+"@couch-kit/host": patch
+---
+
+Extract rate limiting, session management, message validation, and broadcast scheduling out of the host provider into dedicated, unit-tested modules. No behavior change for consumers — the protocol flow, deterministic player IDs, rate limits, disconnect timeout, and broadcast throttling are preserved.

--- a/packages/host/src/broadcast-scheduler.ts
+++ b/packages/host/src/broadcast-scheduler.ts
@@ -1,0 +1,84 @@
+import { MessageTypes, type HostMessage } from "@couch-kit/core";
+
+/** Default state broadcast throttle (~30fps). */
+export const DEFAULT_STATE_THROTTLE_MS = 33;
+
+export type StateUpdateMessage = Extract<
+  HostMessage,
+  { type: typeof MessageTypes.STATE_UPDATE }
+>;
+
+export interface TimerScheduler<TTimer> {
+  setTimeout(callback: () => void, delayMs: number): TTimer;
+  clearTimeout(timer: TTimer): void;
+}
+
+const defaultTimerScheduler: TimerScheduler<ReturnType<typeof setTimeout>> = {
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimeout: (timer) => clearTimeout(timer),
+};
+
+export interface BroadcastSchedulerOptions<TTimer> {
+  stateThrottleMs?: number;
+  scheduler?: TimerScheduler<TTimer>;
+}
+
+/**
+ * Debounced state-broadcast scheduler used by the host provider.
+ * Rapid state changes are coalesced into one broadcast after the latest change.
+ */
+export class BroadcastScheduler<TTimer = ReturnType<typeof setTimeout>> {
+  private stateThrottleMs: number;
+  private readonly scheduler: TimerScheduler<TTimer>;
+  private timer: TTimer | null = null;
+
+  constructor(options: BroadcastSchedulerOptions<TTimer> = {}) {
+    this.stateThrottleMs =
+      options.stateThrottleMs ?? DEFAULT_STATE_THROTTLE_MS;
+    this.scheduler =
+      options.scheduler ??
+      (defaultTimerScheduler as unknown as TimerScheduler<TTimer>);
+  }
+
+  schedule(callback: () => void): void {
+    this.cancel();
+    this.timer = this.scheduler.setTimeout(() => {
+      this.timer = null;
+      callback();
+    }, this.stateThrottleMs);
+  }
+
+  cancel(): void {
+    if (this.timer) {
+      this.scheduler.clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  setStateThrottleMs(stateThrottleMs: number): void {
+    this.stateThrottleMs = stateThrottleMs;
+  }
+
+  hasPendingBroadcast(): boolean {
+    return this.timer !== null;
+  }
+}
+
+export function createStateUpdateMessage(
+  newState: unknown,
+  actions: readonly unknown[],
+  timestamp: number = Date.now(),
+): StateUpdateMessage {
+  return {
+    type: MessageTypes.STATE_UPDATE,
+    payload: {
+      newState,
+      timestamp,
+      ...(actions.length === 1
+        ? { action: actions[0] }
+        : actions.length > 1
+          ? { action: actions }
+          : {}),
+    },
+  };
+}

--- a/packages/host/src/index.tsx
+++ b/packages/host/src/index.tsx
@@ -4,3 +4,7 @@ export * from "./websocket";
 export * from "./network";
 export * from "./assets";
 export * from "./action-recorder";
+export * from "./rate-limiter";
+export * from "./session-manager";
+export * from "./message-validation";
+export * from "./broadcast-scheduler";

--- a/packages/host/src/message-validation.ts
+++ b/packages/host/src/message-validation.ts
@@ -1,0 +1,58 @@
+import { MessageTypes, type ClientMessage } from "@couch-kit/core";
+
+type ClientMessageOf<TType extends ClientMessage["type"]> = Extract<
+  ClientMessage,
+  { type: TType }
+>;
+
+export type ValidatedClientMessage =
+  | {
+      type: typeof MessageTypes.JOIN;
+      payload: {
+        name: string;
+        secret?: unknown;
+        avatar?: unknown;
+        [key: string]: unknown;
+      };
+    }
+  | ClientMessageOf<"ACTION">
+  | ClientMessageOf<"PING">
+  | ClientMessageOf<"ASSETS_LOADED">;
+
+/**
+ * Validates that an incoming message has the expected shape.
+ * Returns true if the message has a processable client-message shape.
+ */
+export function isValidClientMessage(
+  msg: unknown,
+): msg is ValidatedClientMessage {
+  if (typeof msg !== "object" || msg === null) return false;
+  const m = msg as Record<string, unknown>;
+  if (typeof m.type !== "string") return false;
+
+  switch (m.type) {
+    case MessageTypes.JOIN:
+      return (
+        typeof m.payload === "object" &&
+        m.payload !== null &&
+        typeof (m.payload as Record<string, unknown>).name === "string"
+      );
+    case MessageTypes.ACTION:
+      return (
+        typeof m.payload === "object" &&
+        m.payload !== null &&
+        typeof (m.payload as Record<string, unknown>).type === "string"
+      );
+    case MessageTypes.PING:
+      return (
+        typeof m.payload === "object" &&
+        m.payload !== null &&
+        typeof (m.payload as Record<string, unknown>).id === "string" &&
+        typeof (m.payload as Record<string, unknown>).timestamp === "number"
+      );
+    case MessageTypes.ASSETS_LOADED:
+      return m.payload === true;
+    default:
+      return false;
+  }
+}

--- a/packages/host/src/provider.tsx
+++ b/packages/host/src/provider.tsx
@@ -16,20 +16,22 @@ import {
   DEFAULT_WS_PORT_OFFSET,
   DEFAULT_DISCONNECT_TIMEOUT,
   createGameReducer,
-  derivePlayerId,
-  derivePlayerIdLegacy,
   isValidSecret,
   type IGameState,
   type IAction,
   type InternalAction,
-  type ClientMessage,
 } from "@couch-kit/core";
-
-/** Maximum actions per rate-limit window. */
-const RATE_LIMIT_MAX = 60;
-
-/** Rate-limit window duration (ms). */
-const RATE_LIMIT_WINDOW = 1000;
+import { isValidClientMessage } from "./message-validation";
+import { ActionRateLimiter } from "./rate-limiter";
+import {
+  HostSessionManager,
+  type JoinSessionPayload,
+} from "./session-manager";
+import {
+  BroadcastScheduler,
+  DEFAULT_STATE_THROTTLE_MS,
+  createStateUpdateMessage,
+} from "./broadcast-scheduler";
 
 export interface GameHostConfig<S extends IGameState, A extends IAction> {
   initialState: S;
@@ -42,6 +44,8 @@ export interface GameHostConfig<S extends IGameState, A extends IAction> {
   debug?: boolean;
   /** Timeout (ms) before a disconnected player is permanently removed (default: 5 minutes). */
   disconnectTimeout?: number;
+  /** State broadcast throttle interval in milliseconds (default: 33ms, ~30fps). */
+  stateThrottleMs?: number;
   /** Called when a player successfully joins. */
   onPlayerJoined?: (playerId: string, name: string) => void;
   /** Called when a player disconnects. */
@@ -62,42 +66,6 @@ interface GameHostContextValue<S extends IGameState, A extends IAction> {
 const GameHostContext = createContext<GameHostContextValue<any, any> | null>(
   null,
 );
-
-/**
- * Validates that an incoming message has the expected shape.
- * Returns true if the message is a valid ClientMessage, false otherwise.
- */
-function isValidClientMessage(msg: unknown): msg is ClientMessage {
-  if (typeof msg !== "object" || msg === null) return false;
-  const m = msg as Record<string, unknown>;
-  if (typeof m.type !== "string") return false;
-
-  switch (m.type) {
-    case MessageTypes.JOIN:
-      return (
-        typeof m.payload === "object" &&
-        m.payload !== null &&
-        typeof (m.payload as Record<string, unknown>).name === "string"
-      );
-    case MessageTypes.ACTION:
-      return (
-        typeof m.payload === "object" &&
-        m.payload !== null &&
-        typeof (m.payload as Record<string, unknown>).type === "string"
-      );
-    case MessageTypes.PING:
-      return (
-        typeof m.payload === "object" &&
-        m.payload !== null &&
-        typeof (m.payload as Record<string, unknown>).id === "string" &&
-        typeof (m.payload as Record<string, unknown>).timestamp === "number"
-      );
-    case MessageTypes.ASSETS_LOADED:
-      return m.payload === true;
-    default:
-      return false;
-  }
-}
 
 /**
  * React context provider that turns a React Native TV app into a local game server.
@@ -193,15 +161,11 @@ export function GameHostProvider<S extends IGameState, A extends IAction>({
   // 2. Start WebSocket Server (Convention: HTTP port + 2, avoids Metro on 8081)
   const wsServer = useRef<GameWebSocketServer | null>(null);
 
-  // Track active sessions: secret -> socketId
-  const sessions = useRef<Map<string, string>>(new Map());
-
-  // Reverse lookup: socketId -> secret (for disconnect resolution)
-  const reverseMap = useRef<Map<string, string>>(new Map());
-
-  // Stale player cleanup timers: playerId -> timer
-  const cleanupTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
-    new Map(),
+  const sessionManager = useRef(
+    new HostSessionManager({
+      getDisconnectTimeout: () =>
+        configRef.current.disconnectTimeout ?? DEFAULT_DISCONNECT_TIMEOUT,
+    }),
   );
 
   // Track socket IDs that have received their WELCOME message
@@ -212,19 +176,13 @@ export function GameHostProvider<S extends IGameState, A extends IAction>({
     Map<string, { playerId: string; isReconnect: boolean }>
   >(new Map());
 
-  // Cache: socketId -> playerId (avoids async derivation in hot paths)
-  const socketIdToPlayerId = useRef<Map<string, string>>(new Map());
-
   // Track which players have finished loading assets
   const assetsLoaded = useRef<Map<string, boolean>>(new Map());
 
   // Queue of actions dispatched since last broadcast (for STATE_UPDATE.action)
   const actionQueue = useRef<unknown[]>([]);
 
-  // Rate limiting: track action count per socket
-  const rateLimits = useRef<
-    Map<string, { count: number; windowStart: number }>
-  >(new Map());
+  const rateLimiter = useRef(new ActionRateLimiter());
 
   useEffect(() => {
     const port = config.wsPort || httpPort + DEFAULT_WS_PORT_OFFSET;
@@ -274,7 +232,11 @@ export function GameHostProvider<S extends IGameState, A extends IAction>({
           const { secret, ...payload } = message.payload;
 
           // Validate secret format
-          if (!secret || !isValidSecret(secret)) {
+          if (
+            !secret ||
+            typeof secret !== "string" ||
+            !isValidSecret(secret)
+          ) {
             server.send(socketId, {
               type: MessageTypes.ERROR,
               payload: {
@@ -285,80 +247,38 @@ export function GameHostProvider<S extends IGameState, A extends IAction>({
             return;
           }
 
-          // Async dual-derivation: try SHA-256 first, fall back to legacy
-          derivePlayerId(secret).then((hashedId) => {
-            let playerId = hashedId;
+          sessionManager.current
+            .handleJoin<S>(
+              socketId,
+              message.payload as JoinSessionPayload,
+              () => stateRef.current.players,
+            )
+            .then(({ playerId, isReconnect, action }) => {
+              dispatch(action);
 
-            // Migration: if a player exists under the legacy ID, use that instead
-            const legacyId = derivePlayerIdLegacy(secret);
-            if (
-              !stateRef.current.players[playerId] &&
-              stateRef.current.players[legacyId]
-            ) {
-              playerId = legacyId;
-            }
-
-            // Cache the resolved playerId for this socket
-            socketIdToPlayerId.current.set(socketId, playerId);
-
-            // Update session maps
-            sessions.current.set(secret, socketId);
-            reverseMap.current.set(socketId, secret);
-
-            // Cancel any pending cleanup timer for this player
-            const existingTimer = cleanupTimers.current.get(playerId);
-            if (existingTimer) {
-              clearTimeout(existingTimer);
-              cleanupTimers.current.delete(playerId);
-            }
-
-            // Check if this is a returning player
-            const existingPlayer = stateRef.current.players[playerId];
-            if (existingPlayer) {
-              // Reconnection — restore existing player
-              dispatch({
-                type: InternalActionTypes.PLAYER_RECONNECTED,
-                payload: { playerId },
-              } as InternalAction<S>);
-
-              // Reset assets loaded status on reconnect
+              // Initialize/reset assets loaded status
               assetsLoaded.current.set(playerId, false);
 
-              // Queue RECONNECTED message
+              // Queue WELCOME/RECONNECTED message
               pendingWelcome.current.set(socketId, {
                 playerId,
-                isReconnect: true,
+                isReconnect,
               });
-            } else {
-              // New player
-              dispatch({
-                type: InternalActionTypes.PLAYER_JOINED,
-                payload: { id: playerId, ...payload },
-              } as InternalAction<S>);
 
-              // Initialize assets loaded status
-              assetsLoaded.current.set(playerId, false);
-
-              // Queue WELCOME message
-              pendingWelcome.current.set(socketId, {
-                playerId,
-                isReconnect: false,
+              configRef.current.onPlayerJoined?.(playerId, payload.name);
+            })
+            .catch((err) => {
+              if (configRef.current.debug) {
+                console.error("[GameHost] Failed to derive player ID:", err);
+              }
+              server.send(socketId, {
+                type: MessageTypes.ERROR,
+                payload: {
+                  code: "JOIN_FAILED",
+                  message: "Failed to process join request",
+                },
               });
-            }
-
-            configRef.current.onPlayerJoined?.(playerId, payload.name);
-          }).catch((err) => {
-            if (configRef.current.debug) {
-              console.error("[GameHost] Failed to derive player ID:", err);
-            }
-            server.send(socketId, {
-              type: MessageTypes.ERROR,
-              payload: {
-                code: "JOIN_FAILED",
-                message: "Failed to process join request",
-              },
             });
-          });
           break;
         }
 
@@ -390,14 +310,7 @@ export function GameHostProvider<S extends IGameState, A extends IAction>({
           }
 
           // Rate limiting
-          const now = Date.now();
-          let rateInfo = rateLimits.current.get(socketId);
-          if (!rateInfo || now - rateInfo.windowStart > RATE_LIMIT_WINDOW) {
-            rateInfo = { count: 0, windowStart: now };
-            rateLimits.current.set(socketId, rateInfo);
-          }
-          rateInfo.count++;
-          if (rateInfo.count > RATE_LIMIT_MAX) {
+          if (!rateLimiter.current.record(socketId).allowed) {
             if (configRef.current.debug)
               console.warn(`[GameHost] Rate limited ${socketId}`);
             server.send(socketId, {
@@ -411,7 +324,8 @@ export function GameHostProvider<S extends IGameState, A extends IAction>({
           }
 
           // Use cached playerId (populated at JOIN time)
-          const resolvedPlayerId = socketIdToPlayerId.current.get(socketId);
+          const resolvedPlayerId =
+            sessionManager.current.getPlayerIdForSocket(socketId);
           dispatch({ ...actionPayload, playerId: resolvedPlayerId });
           actionQueue.current.push(actionPayload);
           break;
@@ -429,7 +343,8 @@ export function GameHostProvider<S extends IGameState, A extends IAction>({
           break;
 
         case MessageTypes.ASSETS_LOADED: {
-          const loadedPlayerId = socketIdToPlayerId.current.get(socketId);
+          const loadedPlayerId =
+            sessionManager.current.getPlayerIdForSocket(socketId);
           if (loadedPlayerId) {
             assetsLoaded.current.set(loadedPlayerId, true);
             if (configRef.current.debug)
@@ -446,48 +361,36 @@ export function GameHostProvider<S extends IGameState, A extends IAction>({
 
       welcomedClients.current.delete(socketId);
 
-      // Use cached playerId
-      const playerId = socketIdToPlayerId.current.get(socketId);
-      socketIdToPlayerId.current.delete(socketId);
-
-      // Clean up reverse map
-      const secret = reverseMap.current.get(socketId);
-      reverseMap.current.delete(socketId);
-
       // Clean up rate limits
-      rateLimits.current.delete(socketId);
+      rateLimiter.current.reset(socketId);
 
-      if (!playerId || !secret) return; // Unknown socket, nothing to do
+      const result = sessionManager.current.handleDisconnect<S>(socketId);
+      if (result.kind === "unknown") return; // Unknown socket, nothing to do
 
       // Clean up assets loaded tracking
-      assetsLoaded.current.delete(playerId);
+      assetsLoaded.current.delete(result.playerId);
 
-      // RACE GUARD: Only mark as left if this socket is still the active one for this secret
-      if (sessions.current.get(secret) !== socketId) {
+      if (result.kind === "stale") {
         // Player already reconnected on a newer socket — skip
         return;
       }
 
       // Mark disconnected (don't remove from sessions — allow reconnect)
-      dispatch({
-        type: InternalActionTypes.PLAYER_LEFT,
-        payload: { playerId },
-      } as InternalAction<S>);
+      dispatch(result.action);
 
-      configRef.current.onPlayerLeft?.(playerId);
+      configRef.current.onPlayerLeft?.(result.playerId);
 
       // Start stale player cleanup timer
-      const timeout =
-        configRef.current.disconnectTimeout ?? DEFAULT_DISCONNECT_TIMEOUT;
-      const timer = setTimeout(() => {
-        cleanupTimers.current.delete(playerId);
-        sessions.current.delete(secret);
-        dispatch({
-          type: InternalActionTypes.PLAYER_REMOVED,
-          payload: { playerId },
-        } as InternalAction<S>);
-      }, timeout);
-      cleanupTimers.current.set(playerId, timer);
+      sessionManager.current.scheduleRemoval(
+        result.playerId,
+        result.secret,
+        (playerId) => {
+          dispatch({
+            type: InternalActionTypes.PLAYER_REMOVED,
+            payload: { playerId },
+          } as InternalAction<S>);
+        },
+      );
     });
 
     server.on("error", (error) => {
@@ -498,50 +401,42 @@ export function GameHostProvider<S extends IGameState, A extends IAction>({
 
     return () => {
       server.stop();
-      for (const timer of cleanupTimers.current.values()) {
-        clearTimeout(timer);
-      }
-      cleanupTimers.current.clear();
+      sessionManager.current.clearRemovalTimers();
     };
   }, []); // Run once on mount
 
   // 3. Throttled State Broadcasts (~30fps)
   // Batches rapid state changes so at most one broadcast is sent per ~33ms frame,
   // reducing serialization overhead and network traffic for fast-updating games.
-  const broadcastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const broadcastScheduler = useRef(
+    new BroadcastScheduler({
+      stateThrottleMs: config.stateThrottleMs,
+    }),
+  );
+
+  useEffect(() => {
+    broadcastScheduler.current.setStateThrottleMs(
+      config.stateThrottleMs ?? DEFAULT_STATE_THROTTLE_MS,
+    );
+  }, [config.stateThrottleMs]);
 
   const broadcastState = useCallback(() => {
     if (wsServer.current) {
       const actions = actionQueue.current;
       actionQueue.current = [];
-      wsServer.current.broadcast({
-        type: MessageTypes.STATE_UPDATE,
-        payload: {
-          newState: stateRef.current,
-          timestamp: Date.now(),
-          ...(actions.length === 1
-            ? { action: actions[0] }
-            : actions.length > 1
-              ? { action: actions }
-              : {}),
-        },
-      });
+      wsServer.current.broadcast(
+        createStateUpdateMessage(stateRef.current, actions),
+      );
     }
   }, []);
 
   useEffect(() => {
     // Cancel any pending broadcast and schedule a fresh one.
     // This ensures the broadcast always uses the latest stateRef.
-    if (broadcastTimer.current) {
-      clearTimeout(broadcastTimer.current);
-    }
-    broadcastTimer.current = setTimeout(broadcastState, 33); // ~30fps
+    broadcastScheduler.current.schedule(broadcastState);
 
     return () => {
-      if (broadcastTimer.current) {
-        clearTimeout(broadcastTimer.current);
-        broadcastTimer.current = null;
-      }
+      broadcastScheduler.current.cancel();
     };
   }, [state, broadcastState]);
 

--- a/packages/host/src/rate-limiter.ts
+++ b/packages/host/src/rate-limiter.ts
@@ -1,0 +1,66 @@
+/** Maximum actions per rate-limit window. */
+export const RATE_LIMIT_MAX = 60;
+
+/** Rate-limit window duration (ms). */
+export const RATE_LIMIT_WINDOW = 1000;
+
+export interface RateLimitInfo {
+  count: number;
+  windowStart: number;
+}
+
+export interface RateLimitResult extends RateLimitInfo {
+  allowed: boolean;
+}
+
+export interface ActionRateLimiterOptions {
+  maxActions?: number;
+  windowMs?: number;
+  now?: () => number;
+}
+
+/**
+ * Per-socket action limiter that preserves the host provider's original
+ * fixed-window algorithm.
+ */
+export class ActionRateLimiter {
+  private readonly maxActions: number;
+  private readonly windowMs: number;
+  private readonly now: () => number;
+  private readonly limits = new Map<string, RateLimitInfo>();
+
+  constructor(options: ActionRateLimiterOptions = {}) {
+    this.maxActions = options.maxActions ?? RATE_LIMIT_MAX;
+    this.windowMs = options.windowMs ?? RATE_LIMIT_WINDOW;
+    this.now = options.now ?? Date.now;
+  }
+
+  record(socketId: string): RateLimitResult {
+    const now = this.now();
+    let rateInfo = this.limits.get(socketId);
+
+    if (!rateInfo || now - rateInfo.windowStart > this.windowMs) {
+      rateInfo = { count: 0, windowStart: now };
+      this.limits.set(socketId, rateInfo);
+    }
+
+    rateInfo.count++;
+
+    return {
+      ...rateInfo,
+      allowed: rateInfo.count <= this.maxActions,
+    };
+  }
+
+  reset(socketId: string): void {
+    this.limits.delete(socketId);
+  }
+
+  clear(): void {
+    this.limits.clear();
+  }
+
+  get(socketId: string): RateLimitInfo | undefined {
+    return this.limits.get(socketId);
+  }
+}

--- a/packages/host/src/session-manager.ts
+++ b/packages/host/src/session-manager.ts
@@ -1,0 +1,192 @@
+import {
+  DEFAULT_DISCONNECT_TIMEOUT,
+  InternalActionTypes,
+  derivePlayerId,
+  derivePlayerIdLegacy,
+  type IGameState,
+  type InternalAction,
+} from "@couch-kit/core";
+
+export interface SessionTimerScheduler<TTimer> {
+  setTimeout(callback: () => void, delayMs: number): TTimer;
+  clearTimeout(timer: TTimer): void;
+}
+
+const defaultSessionTimerScheduler: SessionTimerScheduler<
+  ReturnType<typeof setTimeout>
+> = {
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimeout: (timer) => clearTimeout(timer),
+};
+
+export interface JoinSessionPayload {
+  name: string;
+  avatar?: string;
+  secret: string;
+}
+
+export interface HostSessionManagerOptions<TTimer> {
+  disconnectTimeout?: number;
+  getDisconnectTimeout?: () => number;
+  scheduler?: SessionTimerScheduler<TTimer>;
+  derivePlayerId?: (secret: string) => Promise<string>;
+  derivePlayerIdLegacy?: (secret: string) => string;
+}
+
+export type JoinSessionResult<S extends IGameState> = {
+  playerId: string;
+  socketId: string;
+  secret: string;
+  isReconnect: boolean;
+  action: InternalAction<S>;
+};
+
+export type DisconnectSessionResult<S extends IGameState> =
+  | { kind: "unknown" }
+  | { kind: "stale"; playerId: string; secret: string }
+  | {
+      kind: "left";
+      playerId: string;
+      secret: string;
+      action: InternalAction<S>;
+    };
+
+type PlayersSource<S extends IGameState> =
+  | S["players"]
+  | (() => S["players"]);
+
+/**
+ * Tracks host player sessions by secret and socket ID, including reconnects and
+ * delayed cleanup of disconnected players.
+ */
+export class HostSessionManager<
+  TTimer = ReturnType<typeof setTimeout>,
+> {
+  private readonly sessions = new Map<string, string>();
+  private readonly reverseMap = new Map<string, string>();
+  private readonly cleanupTimers = new Map<string, TTimer>();
+  private readonly socketIdToPlayerId = new Map<string, string>();
+  private readonly scheduler: SessionTimerScheduler<TTimer>;
+  private readonly getDisconnectTimeout: () => number;
+  private readonly derivePlayerIdFn: (secret: string) => Promise<string>;
+  private readonly derivePlayerIdLegacyFn: (secret: string) => string;
+
+  constructor(options: HostSessionManagerOptions<TTimer> = {}) {
+    this.scheduler =
+      options.scheduler ??
+      (defaultSessionTimerScheduler as unknown as SessionTimerScheduler<TTimer>);
+    this.getDisconnectTimeout =
+      options.getDisconnectTimeout ??
+      (() => options.disconnectTimeout ?? DEFAULT_DISCONNECT_TIMEOUT);
+    this.derivePlayerIdFn = options.derivePlayerId ?? derivePlayerId;
+    this.derivePlayerIdLegacyFn =
+      options.derivePlayerIdLegacy ?? derivePlayerIdLegacy;
+  }
+
+  async handleJoin<S extends IGameState>(
+    socketId: string,
+    payload: JoinSessionPayload,
+    playersSource: PlayersSource<S>,
+  ): Promise<JoinSessionResult<S>> {
+    const hashedId = await this.derivePlayerIdFn(payload.secret);
+    const players =
+      typeof playersSource === "function" ? playersSource() : playersSource;
+    let playerId = hashedId;
+
+    const legacyId = this.derivePlayerIdLegacyFn(payload.secret);
+    if (!players[playerId] && players[legacyId]) {
+      playerId = legacyId;
+    }
+
+    this.socketIdToPlayerId.set(socketId, playerId);
+    this.sessions.set(payload.secret, socketId);
+    this.reverseMap.set(socketId, payload.secret);
+    this.cancelRemoval(playerId);
+
+    const isReconnect = !!players[playerId];
+    const action = isReconnect
+      ? ({
+          type: InternalActionTypes.PLAYER_RECONNECTED,
+          payload: { playerId },
+        } as InternalAction<S>)
+      : ({
+          type: InternalActionTypes.PLAYER_JOINED,
+          payload: { id: playerId, name: payload.name, avatar: payload.avatar },
+        } as InternalAction<S>);
+
+    return {
+      playerId,
+      socketId,
+      secret: payload.secret,
+      isReconnect,
+      action,
+    };
+  }
+
+  handleDisconnect<S extends IGameState>(
+    socketId: string,
+  ): DisconnectSessionResult<S> {
+    const playerId = this.socketIdToPlayerId.get(socketId);
+    this.socketIdToPlayerId.delete(socketId);
+
+    const secret = this.reverseMap.get(socketId);
+    this.reverseMap.delete(socketId);
+
+    if (!playerId || !secret) return { kind: "unknown" };
+
+    if (this.sessions.get(secret) !== socketId) {
+      return { kind: "stale", playerId, secret };
+    }
+
+    return {
+      kind: "left",
+      playerId,
+      secret,
+      action: {
+        type: InternalActionTypes.PLAYER_LEFT,
+        payload: { playerId },
+      } as InternalAction<S>,
+    };
+  }
+
+  scheduleRemoval(
+    playerId: string,
+    secret: string,
+    onRemove: (playerId: string) => void,
+  ): void {
+    const timer = this.scheduler.setTimeout(() => {
+      this.cleanupTimers.delete(playerId);
+      this.sessions.delete(secret);
+      onRemove(playerId);
+    }, this.getDisconnectTimeout());
+
+    this.cleanupTimers.set(playerId, timer);
+  }
+
+  cancelRemoval(playerId: string): void {
+    const existingTimer = this.cleanupTimers.get(playerId);
+    if (existingTimer) {
+      this.scheduler.clearTimeout(existingTimer);
+      this.cleanupTimers.delete(playerId);
+    }
+  }
+
+  clearRemovalTimers(): void {
+    for (const timer of this.cleanupTimers.values()) {
+      this.scheduler.clearTimeout(timer);
+    }
+    this.cleanupTimers.clear();
+  }
+
+  getPlayerIdForSocket(socketId: string): string | undefined {
+    return this.socketIdToPlayerId.get(socketId);
+  }
+
+  getSocketIdForSecret(secret: string): string | undefined {
+    return this.sessions.get(secret);
+  }
+
+  hasPendingRemoval(playerId: string): boolean {
+    return this.cleanupTimers.has(playerId);
+  }
+}

--- a/packages/host/tests/broadcast-scheduler.test.ts
+++ b/packages/host/tests/broadcast-scheduler.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { MessageTypes } from "@couch-kit/core";
+import {
+  BroadcastScheduler,
+  DEFAULT_STATE_THROTTLE_MS,
+  createStateUpdateMessage,
+  type TimerScheduler,
+} from "../src/broadcast-scheduler";
+
+class FakeScheduler implements TimerScheduler<number> {
+  readonly tasks = new Map<number, { callback: () => void; delayMs: number }>();
+  private nextId = 1;
+
+  setTimeout(callback: () => void, delayMs: number): number {
+    const id = this.nextId;
+    this.nextId++;
+    this.tasks.set(id, { callback, delayMs });
+    return id;
+  }
+
+  clearTimeout(timer: number): void {
+    this.tasks.delete(timer);
+  }
+
+  run(timer: number): void {
+    const task = this.tasks.get(timer);
+    if (!task) return;
+    this.tasks.delete(timer);
+    task.callback();
+  }
+}
+
+describe("BroadcastScheduler", () => {
+  test("coalesces rapid schedules into the latest pending broadcast", () => {
+    const fake = new FakeScheduler();
+    const scheduler = new BroadcastScheduler<number>({ scheduler: fake });
+    const calls: string[] = [];
+
+    scheduler.schedule(() => calls.push("first"));
+    scheduler.schedule(() => calls.push("second"));
+
+    expect(fake.tasks.size).toBe(1);
+    const [timer] = Array.from(fake.tasks.keys());
+    fake.run(timer);
+
+    expect(calls).toEqual(["second"]);
+    expect(scheduler.hasPendingBroadcast()).toBe(false);
+  });
+
+  test("uses the default throttle interval and accepts custom intervals", () => {
+    const defaultFake = new FakeScheduler();
+    const defaultScheduler = new BroadcastScheduler<number>({
+      scheduler: defaultFake,
+    });
+    defaultScheduler.schedule(() => {});
+
+    expect(Array.from(defaultFake.tasks.values())[0].delayMs).toBe(
+      DEFAULT_STATE_THROTTLE_MS,
+    );
+
+    const customFake = new FakeScheduler();
+    const customScheduler = new BroadcastScheduler<number>({
+      scheduler: customFake,
+      stateThrottleMs: 10,
+    });
+    customScheduler.schedule(() => {});
+
+    expect(Array.from(customFake.tasks.values())[0].delayMs).toBe(10);
+  });
+
+  test("can update the throttle interval before scheduling", () => {
+    const fake = new FakeScheduler();
+    const scheduler = new BroadcastScheduler<number>({
+      scheduler: fake,
+      stateThrottleMs: 10,
+    });
+
+    scheduler.setStateThrottleMs(25);
+    scheduler.schedule(() => {});
+
+    expect(Array.from(fake.tasks.values())[0].delayMs).toBe(25);
+  });
+});
+
+describe("createStateUpdateMessage", () => {
+  test("omits action when no actions were queued", () => {
+    const message = createStateUpdateMessage({ status: "lobby" }, [], 123);
+
+    expect(message).toEqual({
+      type: MessageTypes.STATE_UPDATE,
+      payload: {
+        newState: { status: "lobby" },
+        timestamp: 123,
+      },
+    });
+  });
+
+  test("includes a single action as an object and many actions as an array", () => {
+    const single = createStateUpdateMessage(
+      { status: "lobby" },
+      [{ type: "A" }],
+      123,
+    );
+    const many = createStateUpdateMessage(
+      { status: "lobby" },
+      [{ type: "A" }, { type: "B" }],
+      123,
+    );
+
+    expect(single.payload.action).toEqual({ type: "A" });
+    expect(many.payload.action).toEqual([{ type: "A" }, { type: "B" }]);
+  });
+});

--- a/packages/host/tests/message-validation.test.ts
+++ b/packages/host/tests/message-validation.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { MessageTypes } from "@couch-kit/core";
+import { isValidClientMessage } from "../src/message-validation";
+
+describe("isValidClientMessage", () => {
+  test("accepts valid client messages", () => {
+    expect(
+      isValidClientMessage({
+        type: MessageTypes.JOIN,
+        payload: { name: "Alice", secret: "not-validated-here" },
+      }),
+    ).toBe(true);
+    expect(
+      isValidClientMessage({
+        type: MessageTypes.ACTION,
+        payload: { type: "BUZZ", payload: { value: 1 } },
+      }),
+    ).toBe(true);
+    expect(
+      isValidClientMessage({
+        type: MessageTypes.PING,
+        payload: { id: "ping-1", timestamp: 123 },
+      }),
+    ).toBe(true);
+    expect(
+      isValidClientMessage({
+        type: MessageTypes.ASSETS_LOADED,
+        payload: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("preserves existing JOIN validation by requiring only a name shape", () => {
+    expect(
+      isValidClientMessage({
+        type: MessageTypes.JOIN,
+        payload: { name: "Alice" },
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects invalid message shapes", () => {
+    const invalidMessages: unknown[] = [
+      null,
+      undefined,
+      "JOIN",
+      42,
+      {},
+      { type: 123 },
+      { type: "UNKNOWN", payload: {} },
+      { type: MessageTypes.JOIN },
+      { type: MessageTypes.JOIN, payload: null },
+      { type: MessageTypes.JOIN, payload: { name: 123 } },
+      { type: MessageTypes.ACTION, payload: null },
+      { type: MessageTypes.ACTION, payload: { type: 123 } },
+      { type: MessageTypes.PING, payload: { id: "ping-1" } },
+      { type: MessageTypes.PING, payload: { id: 123, timestamp: 123 } },
+      { type: MessageTypes.PING, payload: { id: "ping-1", timestamp: "123" } },
+      { type: MessageTypes.ASSETS_LOADED, payload: false },
+      { type: MessageTypes.ASSETS_LOADED, payload: {} },
+    ];
+
+    for (const message of invalidMessages) {
+      expect(isValidClientMessage(message)).toBe(false);
+    }
+  });
+});

--- a/packages/host/tests/rate-limiter.test.ts
+++ b/packages/host/tests/rate-limiter.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ActionRateLimiter,
+  RATE_LIMIT_MAX,
+  RATE_LIMIT_WINDOW,
+} from "../src/rate-limiter";
+
+describe("ActionRateLimiter", () => {
+  test("allows actions up to the configured limit", () => {
+    const now = 1000;
+    const limiter = new ActionRateLimiter({ now: () => now });
+
+    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+      expect(limiter.record("socket-1").allowed).toBe(true);
+    }
+
+    expect(limiter.get("socket-1")).toEqual({
+      count: RATE_LIMIT_MAX,
+      windowStart: now,
+    });
+  });
+
+  test("blocks actions over the configured limit", () => {
+    const limiter = new ActionRateLimiter({ now: () => 1000 });
+
+    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+      limiter.record("socket-1");
+    }
+
+    const blocked = limiter.record("socket-1");
+
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.count).toBe(RATE_LIMIT_MAX + 1);
+  });
+
+  test("resets only after the window has fully elapsed", () => {
+    let now = 1000;
+    const limiter = new ActionRateLimiter({ now: () => now });
+
+    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+      limiter.record("socket-1");
+    }
+
+    now += RATE_LIMIT_WINDOW;
+    expect(limiter.record("socket-1").allowed).toBe(false);
+
+    now += 1;
+    const allowedAfterSlide = limiter.record("socket-1");
+
+    expect(allowedAfterSlide.allowed).toBe(true);
+    expect(allowedAfterSlide.count).toBe(1);
+    expect(allowedAfterSlide.windowStart).toBe(now);
+  });
+
+  test("tracks sockets independently and can reset one socket", () => {
+    const limiter = new ActionRateLimiter({ maxActions: 1, now: () => 1000 });
+
+    expect(limiter.record("socket-1").allowed).toBe(true);
+    expect(limiter.record("socket-1").allowed).toBe(false);
+    expect(limiter.record("socket-2").allowed).toBe(true);
+
+    limiter.reset("socket-1");
+
+    expect(limiter.record("socket-1").allowed).toBe(true);
+    expect(limiter.record("socket-2").allowed).toBe(false);
+  });
+});

--- a/packages/host/tests/session-manager.test.ts
+++ b/packages/host/tests/session-manager.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_DISCONNECT_TIMEOUT,
+  InternalActionTypes,
+  type IPlayer,
+} from "@couch-kit/core";
+import {
+  HostSessionManager,
+  type SessionTimerScheduler,
+} from "../src/session-manager";
+
+interface TestState {
+  status: string;
+  players: Record<string, IPlayer>;
+}
+
+class FakeScheduler implements SessionTimerScheduler<number> {
+  readonly tasks = new Map<number, { callback: () => void; delayMs: number }>();
+  private nextId = 1;
+
+  setTimeout(callback: () => void, delayMs: number): number {
+    const id = this.nextId;
+    this.nextId++;
+    this.tasks.set(id, { callback, delayMs });
+    return id;
+  }
+
+  clearTimeout(timer: number): void {
+    this.tasks.delete(timer);
+  }
+
+  run(timer: number): void {
+    const task = this.tasks.get(timer);
+    if (!task) return;
+    this.tasks.delete(timer);
+    task.callback();
+  }
+}
+
+function createPlayer(id: string, connected = true): IPlayer {
+  return {
+    id,
+    name: "Alice",
+    isHost: false,
+    connected,
+  };
+}
+
+function createManager(scheduler = new FakeScheduler()) {
+  return {
+    scheduler,
+    manager: new HostSessionManager<number>({
+      scheduler,
+      derivePlayerId: async (secret) => `hashed-${secret}`,
+      derivePlayerIdLegacy: (secret) => `legacy-${secret}`,
+    }),
+  };
+}
+
+describe("HostSessionManager", () => {
+  test("derives a stable player ID for the same secret", async () => {
+    const { manager } = createManager();
+    const secret = "secret-a";
+
+    const first = await manager.handleJoin<TestState>(
+      "socket-1",
+      { name: "Alice", secret },
+      {},
+    );
+    const second = await manager.handleJoin<TestState>(
+      "socket-2",
+      { name: "Alice", secret },
+      {},
+    );
+
+    expect(first.playerId).toBe(`hashed-${secret}`);
+    expect(second.playerId).toBe(first.playerId);
+    expect(manager.getPlayerIdForSocket("socket-2")).toBe(first.playerId);
+    expect(manager.getSocketIdForSecret(secret)).toBe("socket-2");
+  });
+
+  test("returns PLAYER_RECONNECTED for an existing player and treats old sockets as stale", async () => {
+    const { manager } = createManager();
+    const secret = "secret-a";
+    const joined = await manager.handleJoin<TestState>(
+      "socket-1",
+      { name: "Alice", secret },
+      {},
+    );
+
+    const reconnected = await manager.handleJoin<TestState>(
+      "socket-2",
+      { name: "Alice", secret },
+      { [joined.playerId]: createPlayer(joined.playerId, false) },
+    );
+    const staleDisconnect = manager.handleDisconnect<TestState>("socket-1");
+
+    expect(reconnected.playerId).toBe(joined.playerId);
+    expect(reconnected.isReconnect).toBe(true);
+    expect(reconnected.action).toEqual({
+      type: InternalActionTypes.PLAYER_RECONNECTED,
+      payload: { playerId: joined.playerId },
+    });
+    expect(staleDisconnect).toEqual({
+      kind: "stale",
+      playerId: joined.playerId,
+      secret,
+    });
+  });
+
+  test("uses the legacy player ID when existing state contains only the legacy ID", async () => {
+    const { manager } = createManager();
+    const secret = "secret-a";
+    const legacyId = `legacy-${secret}`;
+
+    const result = await manager.handleJoin<TestState>(
+      "socket-1",
+      { name: "Alice", secret },
+      { [legacyId]: createPlayer(legacyId, false) },
+    );
+
+    expect(result.playerId).toBe(legacyId);
+    expect(result.action).toEqual({
+      type: InternalActionTypes.PLAYER_RECONNECTED,
+      payload: { playerId: legacyId },
+    });
+  });
+
+  test("classifies reconnects against latest players after async ID derivation", async () => {
+    const secret = "secret-a";
+    const playerId = `hashed-${secret}`;
+    let resolveDerivation: (playerId: string) => void = () => {};
+    let latestPlayers: TestState["players"] = {
+      [playerId]: createPlayer(playerId, false),
+    };
+    const manager = new HostSessionManager<number>({
+      scheduler: new FakeScheduler(),
+      derivePlayerId: () =>
+        new Promise((resolve) => {
+          resolveDerivation = resolve;
+        }),
+      derivePlayerIdLegacy: (value) => `legacy-${value}`,
+    });
+
+    const join = manager.handleJoin<TestState>(
+      "socket-1",
+      { name: "Alice", secret },
+      () => latestPlayers,
+    );
+    latestPlayers = {};
+    resolveDerivation(playerId);
+    const result = await join;
+
+    expect(result.isReconnect).toBe(false);
+    expect(result.action).toEqual({
+      type: InternalActionTypes.PLAYER_JOINED,
+      payload: { id: playerId, name: "Alice", avatar: undefined },
+    });
+  });
+
+  test("schedules PLAYER_REMOVED after the default five-minute disconnect timeout", async () => {
+    const { manager, scheduler } = createManager();
+    const secret = "secret-a";
+    const joined = await manager.handleJoin<TestState>(
+      "socket-1",
+      { name: "Alice", secret },
+      {},
+    );
+    const disconnect = manager.handleDisconnect<TestState>("socket-1");
+    const removed: string[] = [];
+
+    expect(disconnect.kind).toBe("left");
+    if (disconnect.kind !== "left") return;
+
+    manager.scheduleRemoval(disconnect.playerId, disconnect.secret, (playerId) => {
+      removed.push(playerId);
+    });
+
+    expect(scheduler.tasks.size).toBe(1);
+    const [timer, task] = Array.from(scheduler.tasks.entries())[0];
+    expect(task.delayMs).toBe(DEFAULT_DISCONNECT_TIMEOUT);
+
+    scheduler.run(timer);
+
+    expect(removed).toEqual([joined.playerId]);
+    expect(manager.getSocketIdForSecret(secret)).toBeUndefined();
+  });
+
+  test("cancels pending removal when the player reconnects before timeout", async () => {
+    const { manager, scheduler } = createManager();
+    const secret = "secret-a";
+    const joined = await manager.handleJoin<TestState>(
+      "socket-1",
+      { name: "Alice", secret },
+      {},
+    );
+    const disconnect = manager.handleDisconnect<TestState>("socket-1");
+    const removed: string[] = [];
+
+    expect(disconnect.kind).toBe("left");
+    if (disconnect.kind !== "left") return;
+
+    manager.scheduleRemoval(disconnect.playerId, disconnect.secret, (playerId) => {
+      removed.push(playerId);
+    });
+    await manager.handleJoin<TestState>(
+      "socket-2",
+      { name: "Alice", secret },
+      { [joined.playerId]: createPlayer(joined.playerId, false) },
+    );
+
+    expect(scheduler.tasks.size).toBe(0);
+    expect(removed).toEqual([]);
+    expect(manager.getSocketIdForSecret(secret)).toBe("socket-2");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #44.

Extracts the host provider's runtime concerns into four dedicated, unit-tested modules. **No behavior change** — `provider.tsx` now composes these helpers; the protocol flow, deterministic/legacy player IDs, rate limits, disconnect timeout, and broadcast throttling are all preserved.

`provider.tsx` shrinks by ~190 lines (279 changed).

### New modules (`packages/host/src/`)
- **`rate-limiter.ts`** — `ActionRateLimiter`, the per-socket fixed-window limiter (60 actions/sec).
- **`session-manager.ts`** — `HostSessionManager`: join/reconnect, secret↔socket mapping, deterministic + legacy player-ID fallback, and delayed cleanup of disconnected players (5-min timeout).
- **`message-validation.ts`** — `isValidClientMessage` type guard for JOIN/ACTION/PING/ASSETS_LOADED.
- **`broadcast-scheduler.ts`** — `BroadcastScheduler` (debounced ~30fps coalescing) + `createStateUpdateMessage`.

All are exported from the host index, with injectable schedulers/clocks for deterministic testing.

### Tests
18 new host tests across 4 files (rate limits, reconnect/removal timers, validation, broadcast coalescing). Host suite: **47 pass**.

### Changeset
Patch bump for `@couch-kit/host`.

## Verification
`bun run build && bun run typecheck && bun run test && bun run lint` all green (only the pre-existing unrelated `core/reducer.ts` warning remains).