### PR TITLE
docs: sync docs with Renovate + devtools package

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,14 +6,15 @@ couch-kit is a framework for building TV party games. The host runs on Android T
 
 ## Monorepo Structure
 
-4 packages under `packages/`, managed with Bun workspaces:
+5 packages under `packages/`, managed with Bun workspaces:
 
-| Package  | npm Name            | Purpose                                                                                           |
-| -------- | ------------------- | ------------------------------------------------------------------------------------------------- |
-| `core`   | `@couch-kit/core`   | Shared types, protocol definitions, `createGameReducer`                                           |
-| `client` | `@couch-kit/client` | Web SDK — `CouchKitProvider`, `useCouchKit()`, `useServerTime()`, `useAssets()`                   |
-| `host`   | `@couch-kit/host`   | Android TV SDK — `GameHostProvider`, `useRoom()`, `usePlayers()`, `useGameState()`, `useAssets()` |
-| `cli`    | `@couch-kit/cli`    | CLI tooling — `couch-kit bundle` bundles web client into Android assets                           |
+| Package    | npm Name              | Purpose                                                                                           |
+| ---------- | --------------------- | ------------------------------------------------------------------------------------------------- |
+| `core`     | `@couch-kit/core`     | Shared types, protocol definitions, `createGameReducer`                                            |
+| `client`   | `@couch-kit/client`   | Web SDK — `useGameClient()`, `useServerTime()`, `usePreload()`, `useDebugPanel()`                  |
+| `host`     | `@couch-kit/host`     | Android TV SDK — `GameHostProvider`, `useGameHost()`, `useExtractAssets()`, `useActionRecorder()`  |
+| `cli`      | `@couch-kit/cli`      | CLI tooling — `init`, `bundle`, `simulate`, `replay`, `dev`                                         |
+| `devtools` | `@couch-kit/devtools` | Optional `DebugOverlay` component for web controllers                                              |
 
 ## Build Order
 
@@ -73,14 +74,15 @@ bun run typecheck # typechecks all packages
 ## Release Flow
 
 1. PRs merged to `main` with changesets → CI creates "Version Packages" PR
-2. Version PR merged → CI publishes to npm with provenance
-3. After publish → issues auto-created in consumer apps (domino, buzz) assigned to Copilot
+2. Version PR merged → CI publishes to npm with provenance (OIDC Trusted Publishing)
+3. After publish → each consumer repo's **Renovate** opens a PR bumping `@couch-kit/*` (minor/patch auto-merge, major held for review)
 
 ## Consumer Apps
 
-Two apps consume couch-kit via npm:
+Three apps consume couch-kit via npm:
 
 - [domino-party-game](https://github.com/faluciano/domino-party-game) — Dominican domino (complex, 4 players, teams, bots)
 - [buzz-tv-party-game](https://github.com/faluciano/buzz-tv-party-game) — Buzzer game (starter template)
+- [card-game-engine](https://github.com/faluciano/card-game-engine) — JSON-driven card game engine
 
-Both follow the same pattern: `shared` (reducer + types) → `client` (web UI) → `host` (TV display)
+All follow the same pattern: `shared` (reducer + types) → `client` (web UI) → `host` (TV display)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ Key test files:
 
 1. PRs merged to `main` with changesets → CI creates "Version Packages" PR
 2. Version PR merged → CI publishes to npm with provenance (OIDC Trusted Publishing, no NPM_TOKEN)
-3. After publish → each consumer repo's **Dependabot** opens a PR bumping `@couch-kit/*`
+3. After publish → each consumer repo's **Renovate** opens a PR bumping `@couch-kit/*`
 4. Each consumer's CI (typecheck + build) gates the PR; patch/minor auto-merge, **major** bumps are held for manual review
 
-Consumers use native Dependabot (`.github/dependabot.yml`) + an auto-merge workflow — there is no custom dispatch glue in this repo.
+Consumers use Renovate (`renovate.json`, scoped to `@couch-kit/*` and grouped into one PR) with auto-merge for minor/patch/digest updates — there is no custom dispatch glue in this repo. Renovate (not Dependabot) is used because Dependabot does not regenerate Bun workspace lockfiles.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ bun run typecheck  # type-check
 
 ## Monorepo Structure
 
-Four packages under `packages/`:
+Five packages under `packages/`:
 
 | Package             | Description                            |
 | ------------------- | -------------------------------------- |
@@ -24,6 +24,7 @@ Four packages under `packages/`:
 | `@couch-kit/client` | React hooks for phone controllers      |
 | `@couch-kit/host`   | React Native TV host                   |
 | `@couch-kit/cli`    | CLI tools (bundle, simulate, scaffold) |
+| `@couch-kit/devtools` | Debug overlay component for web controllers |
 
 ## Making Changes
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Turn an Android TV / Fire TV into a local party-game console and use phones as w
 [![@couch-kit/client](https://img.shields.io/npm/dt/@couch-kit/client?label=%40couch-kit%2Fclient)](https://www.npmjs.com/package/@couch-kit/client)
 [![@couch-kit/core](https://img.shields.io/npm/dt/@couch-kit/core?label=%40couch-kit%2Fcore)](https://www.npmjs.com/package/@couch-kit/core)
 [![@couch-kit/cli](https://img.shields.io/npm/dt/@couch-kit/cli?label=%40couch-kit%2Fcli)](https://www.npmjs.com/package/@couch-kit/cli)
+[![@couch-kit/devtools](https://img.shields.io/npm/dt/@couch-kit/devtools?label=%40couch-kit%2Fdevtools)](https://www.npmjs.com/package/@couch-kit/devtools)
 
 ---
 
@@ -271,7 +272,7 @@ bun install
 
 ### 2. Building the Libraries
 
-The packages (`host`, `client`, `core`, `cli`) are located in `packages/*`. You can build them all at once:
+The packages (`host`, `client`, `core`, `cli`, `devtools`) are located in `packages/*`. You can build them all at once:
 
 ```bash
 bun run build
@@ -355,6 +356,7 @@ When you make changes to the library:
 | **`@couch-kit/client`** | Runs on the phone browser. Connects to the host and renders the controller UI.             |
 | **`@couch-kit/core`**   | Shared TypeScript types and protocol definitions.                                          |
 | **`@couch-kit/cli`**    | CLI tools to scaffold, bundle, and simulate web controllers                                |
+| **`@couch-kit/devtools`** | Optional debug overlay component for web controllers (state inspector).                   |
 
 ## 🔄 Release Flow
 
@@ -366,11 +368,13 @@ This repo uses [Changesets](https://github.com/changesets/changesets) for versio
 2. On merge to `main`, the release workflow either:
    - Creates a **"Version Packages"** PR if there are pending changesets
    - **Publishes to npm** if the version PR was merged (no pending changesets)
-3. Consumer app repos ([domino](https://github.com/faluciano/domino-party-game), [buzz](https://github.com/faluciano/buzz-tv-party-game), [card-game-engine](https://github.com/faluciano/card-game-engine)) use **[Dependabot](https://docs.github.com/en/code-security/dependabot)** to pick up new `@couch-kit/*` releases and open update PRs automatically
+3. Consumer app repos ([domino](https://github.com/faluciano/domino-party-game), [buzz](https://github.com/faluciano/buzz-tv-party-game), [card-game-engine](https://github.com/faluciano/card-game-engine)) use **[Renovate](https://docs.renovatebot.com/)** to pick up new `@couch-kit/*` releases and open update PRs automatically
 
 ### Dogfooding consumers
 
-Each consumer repo runs its own CI (typecheck + build) on the Dependabot PR. Patch/minor updates that pass CI are auto-merged; **major version bumps** skip auto-merge and require manual review, so breaking changes surface as a failing or held PR in each app.
+Each consumer repo has a `renovate.json` scoped to the `@couch-kit/*` packages (grouped into a single PR). Renovate regenerates the Bun lockfile, then each repo runs its own CI (typecheck + build) on the PR. Patch/minor/digest updates that pass CI are auto-merged by Renovate; **major version bumps** skip auto-merge and require manual review, so breaking changes surface as a held PR in each app.
+
+> Renovate (not Dependabot) is used because Dependabot does not regenerate Bun workspace lockfiles, which causes `bun install --frozen-lockfile` to fail in CI.
 
 ## 📚 Documentation
 
@@ -378,6 +382,7 @@ Each consumer repo runs its own CI (typecheck + build) on the Dependabot PR. Pat
 - [Client Documentation](./packages/client/README.md)
 - [Core Documentation](./packages/core/README.md)
 - [CLI Documentation](./packages/cli/README.md)
+- [Devtools Documentation](./packages/devtools/README.md)
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Brings all documentation in line with the current state of the repo. No source/package changes — docs only.

### What was stale
- **Dependabot → Renovate**: `README.md` and `AGENTS.md` still described consumer apps (buzz/domino/card-game-engine) as using Dependabot. They moved to **Renovate** (Dependabot can't regenerate Bun workspace lockfiles, which breaks `bun install --frozen-lockfile`). Verified this session: each consumer has a `renovate.json` scoped to `@couch-kit/*`, and update PRs auto-merge via `app/renovate`.
- **Missing `@couch-kit/devtools`**: the 5th package was absent from the README (npm badge, build list, architecture table, docs link), `CONTRIBUTING.md`, and `.opencode/instructions.md` (still said "four packages").
- **`.github/copilot-instructions.md` had fictional APIs**: documented `CouchKitProvider`, `useCouchKit()`, `useRoom()`, `usePlayers()`, `useGameState()`, `useAssets()` — none of which exist. Corrected to the real exports (`useGameClient`, `useServerTime`, `usePreload`, `useDebugPanel`, `GameHostProvider`, `useGameHost`, `useExtractAssets`, `useActionRecorder`). Also fixed "4 packages" → 5, "two apps" → three, and the outdated release-flow step.

### Verification
- All exported APIs cross-checked against `packages/{client,host,devtools}/src`.
- All relative doc links resolve.
- Renovate behavior confirmed against the live consumer repos.

No changeset needed (no files under `packages/`).