### PR TITLE
docs: render mermaid diagrams on the TypeDoc Pages site

### DIFF
--- a/static/mermaid-init.js
+++ b/static/mermaid-init.js
@@ -1,0 +1,46 @@
+// Renders the ```mermaid fenced code blocks that TypeDoc emits as
+// `<pre><code class="mermaid">…</code></pre>` into actual diagrams.
+// TypeDoc does not bundle mermaid, so we load it on demand from a CDN.
+(function () {
+  function collect() {
+    return Array.from(document.querySelectorAll("pre > code.mermaid"));
+  }
+
+  function prefersDark() {
+    return (
+      document.documentElement.dataset.theme === "dark" ||
+      (document.documentElement.dataset.theme !== "light" &&
+        window.matchMedia &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches)
+    );
+  }
+
+  async function render() {
+    const blocks = collect();
+    if (blocks.length === 0) return;
+
+    const nodes = blocks.map((code) => {
+      const pre = code.parentElement;
+      const div = document.createElement("div");
+      div.className = "mermaid";
+      div.textContent = code.textContent;
+      pre.replaceWith(div);
+      return div;
+    });
+
+    const { default: mermaid } = await import(
+      "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs"
+    );
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: prefersDark() ? "dark" : "default",
+    });
+    await mermaid.run({ nodes });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", render);
+  } else {
+    render();
+  }
+})();

--- a/typedoc.json
+++ b/typedoc.json
@@ -11,6 +11,7 @@
   "out": "docs",
   "name": "couch-kit",
   "readme": "README.md",
+  "customJs": "static/mermaid-init.js",
   "excludePrivate": true,
   "excludeInternal": true,
   "includeVersion": true,


### PR DESCRIPTION
## Problem

On the published docs site (https://faluciano.github.io/react-native-couch-kit/), the two README architecture diagrams render as **raw text**, not diagrams. TypeDoc emits ```mermaid fenced blocks as `<pre><code class="mermaid">…</code></pre>` but never loads mermaid.js, so nothing renders them.

## Fix

Add `static/mermaid-init.js` and wire it via TypeDoc's `customJs`. On load it finds `code.mermaid` blocks, lazy-loads mermaid 11 from a CDN, and renders them — theme-matched to the site's light/dark mode.

## Verified

Built docs locally and opened in a browser: both diagrams render as SVG (`2 svg / 0 raw code`), confirmed visually in dark mode. No source/package files touched (config + static asset only) → no changeset needed.