### PR TITLE
fix(cli): update init scaffold to current deps, clarify scope

### DIFF
--- a/.changeset/update-cli-init.md
+++ b/.changeset/update-cli-init.md
@@ -1,0 +1,5 @@
+---
+"@couch-kit/cli": patch
+---
+
+Update `init` scaffold to current dependency versions (React 19, Vite 6, TS 5.7) and wire App.tsx to the generated reducer file

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,7 +14,7 @@ bun add -d @couch-kit/cli
 
 ### `init`
 
-Scaffolds a new web controller project (Vite + React + TypeScript) configured to work with Couch Kit.
+Scaffolds a web controller project (Vite + React + TypeScript) to add to an existing host app. This creates only the phone/tablet side — for a full game project (host + client + shared), clone the [Buzz starter](https://github.com/faluciano/buzz-tv-party-game).
 
 ```bash
 bunx couch-kit init web-controller

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -43,16 +43,16 @@ export const initCommand = new Command("init")
           preview: "vite preview",
         },
         dependencies: {
-          react: "^18.2.0",
-          "react-dom": "^18.2.0",
-          "@couch-kit/client": "^0.4.3",
+          react: "^19.0.0",
+          "react-dom": "^19.0.0",
+          "@couch-kit/client": "^0.8.0",
         },
         devDependencies: {
-          "@types/react": "^18.2.66",
-          "@types/react-dom": "^18.2.22",
-          "@vitejs/plugin-react": "^4.2.1",
-          typescript: "^5.2.2",
-          vite: "^5.2.0",
+          "@types/react": "^19.0.0",
+          "@types/react-dom": "^19.0.0",
+          "@vitejs/plugin-react": "^6.0.0",
+          typescript: "^5.7.0",
+          vite: "^6.0.0",
         },
       };
 
@@ -171,11 +171,12 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         path.join(targetDir, "src/App.tsx"),
         `
 import { useGameClient } from '@couch-kit/client';
+import { gameReducer, initialState } from './reducer';
 
 function App() {
   const { status, playerId, sendAction } = useGameClient({
-    initialState: { count: 0 },
-    reducer: (state, action) => state // Dummy reducer
+    initialState,
+    reducer: gameReducer,
   });
 
   return (
@@ -183,7 +184,7 @@ function App() {
         <h1>Controller</h1>
         <p>Status: {status}</p>
         <p>ID: {playerId || 'Connecting...'}</p>
-        <button onClick={() => sendAction({ type: 'BUZZ' })} 
+        <button onClick={() => sendAction({ type: 'SCORE' })} 
                 style={{ fontSize: 24, padding: '20px 40px', width: '100%' }}>
             BUZZ!
         </button>


### PR DESCRIPTION
The `init` command was scaffolding projects with stale dependencies (React 18, Vite 5, TS 5.2, `@couch-kit/client@^0.4.3`). This updates to current versions and improves the generated code.

## Changes

**Dependency bumps:**
- `react` / `react-dom`: `^18.2.0` → `^19.0.0`
- `@types/react` / `@types/react-dom`: `^18.x` → `^19.0.0`
- `vite`: `^5.2.0` → `^6.0.0`
- `@vitejs/plugin-react`: `^4.2.1` → `^6.0.0`
- `typescript`: `^5.2.2` → `^5.7.0`
- `@couch-kit/client`: `^0.4.3` → `^0.8.0`

**Code quality:**
- `App.tsx` now imports from the generated `reducer.ts` instead of an inline dummy reducer
- Action type matches the generated reducer (`SCORE` instead of `BUZZ`)

**Docs:**
- CLI README clarifies `init` is for adding a web controller to an existing host, not for starting a full project
- Points to Buzz starter for full game scaffolding
