### PR TITLE
fix(core): derive player IDs with real SHA-256 on Hermes

### DIFF
--- a/.changeset/secure-player-id-hermes.md
+++ b/.changeset/secure-player-id-hermes.md
@@ -1,0 +1,16 @@
+---
+"@couch-kit/core": patch
+---
+
+**Security:** Derive public player IDs with a real SHA-256 on React Native / Hermes.
+
+`derivePlayerId` hashes the session secret with SHA-256 via the Web Crypto API,
+but Hermes (where the host runs) does not expose `crypto.subtle`. The previous
+fallback used `derivePlayerIdLegacy`, which simply truncated the secret —
+exposing the first half of the raw session token as the public `playerId`
+broadcast in game state.
+
+The fallback now uses a dependency-free pure-JS SHA-256 that produces the exact
+same digest as `crypto.subtle`, so player IDs are secure and identical across
+all host runtimes. `derivePlayerIdLegacy` is retained only for reconnect
+migration of players who joined under the old scheme.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,5 +1,8 @@
 /** Shared constants for Couch Kit protocol defaults. */
 
+import { sha256Hex } from "./sha256";
+
+
 /** Default HTTP port for the static file server. */
 export const DEFAULT_HTTP_PORT = 8080;
 
@@ -82,8 +85,11 @@ export function isValidSecret(secret: string): boolean {
  * Takes the first 16 hex characters of the SHA-256 hash, producing
  * a deterministic ID that cannot be reversed to recover the secret.
  *
- * Falls back to {@link derivePlayerIdLegacy} when the Web Crypto API
- * (`crypto.subtle`) is unavailable (e.g. React Native / Hermes).
+ * Uses the Web Crypto API (`crypto.subtle`) when available (browser / Node),
+ * and a dependency-free pure-JS SHA-256 fallback otherwise (e.g. React Native
+ * / Hermes, which does not expose `crypto.subtle`). Both paths produce the
+ * same digest, so the derived ID is identical across host runtimes and never
+ * leaks any part of the secret.
  */
 export async function derivePlayerId(secret: string): Promise<string> {
   if (
@@ -98,8 +104,10 @@ export async function derivePlayerId(secret: string): Promise<string> {
       .slice(0, 16);
   }
 
-  // Web Crypto unavailable (React Native / Hermes) — fall back to legacy derivation
-  return derivePlayerIdLegacy(secret);
+  // Web Crypto unavailable (React Native / Hermes) — use the pure-JS SHA-256
+  // fallback. This still produces a secure one-way hash (unlike the deprecated
+  // legacy derivation, which exposed the first half of the secret).
+  return sha256Hex(secret).slice(0, 16);
 }
 
 /**

--- a/packages/core/src/sha256.ts
+++ b/packages/core/src/sha256.ts
@@ -1,0 +1,169 @@
+/**
+ * Dependency-free SHA-256 implementation.
+ *
+ * Couch Kit derives public player IDs from a secret using SHA-256. Browsers and
+ * Node expose this via the Web Crypto API (`crypto.subtle.digest`), but React
+ * Native / Hermes — where the host actually runs — does **not** provide
+ * `crypto.subtle` by default. This pure-JS implementation is used as the
+ * fallback so the host still produces a proper one-way hash instead of leaking
+ * part of the secret. It is byte-for-byte compatible with
+ * `crypto.subtle.digest("SHA-256", ...)`, so player IDs are stable regardless
+ * of which runtime the host uses.
+ */
+
+/** Round constants (first 32 bits of the fractional parts of the cube roots of the first 64 primes). */
+// prettier-ignore
+const K = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+/** Encode a JS string as UTF-8 bytes without relying on the global `TextEncoder`. */
+function utf8Bytes(str: string): number[] {
+  const bytes: number[] = [];
+  for (let i = 0; i < str.length; i++) {
+    let code = str.charCodeAt(i);
+    // Combine surrogate pairs into a single code point.
+    if (code >= 0xd800 && code <= 0xdbff && i + 1 < str.length) {
+      const next = str.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        code = 0x10000 + ((code - 0xd800) << 10) + (next - 0xdc00);
+        i++;
+      }
+    }
+    if (code < 0x80) {
+      bytes.push(code);
+    } else if (code < 0x800) {
+      bytes.push(0xc0 | (code >> 6), 0x80 | (code & 0x3f));
+    } else if (code < 0x10000) {
+      bytes.push(
+        0xe0 | (code >> 12),
+        0x80 | ((code >> 6) & 0x3f),
+        0x80 | (code & 0x3f),
+      );
+    } else {
+      bytes.push(
+        0xf0 | (code >> 18),
+        0x80 | ((code >> 12) & 0x3f),
+        0x80 | ((code >> 6) & 0x3f),
+        0x80 | (code & 0x3f),
+      );
+    }
+  }
+  return bytes;
+}
+
+const rotr = (x: number, n: number): number => (x >>> n) | (x << (32 - n));
+
+/**
+ * Compute the SHA-256 digest of a UTF-8 string.
+ *
+ * @param message - The string to hash.
+ * @returns Lowercase hex-encoded 256-bit digest (64 characters).
+ */
+export function sha256Hex(message: string): string {
+  const bytes = utf8Bytes(message);
+  const bitLen = bytes.length * 8;
+
+  // Padding: append 0x80, then zeros, then the 64-bit big-endian length.
+  bytes.push(0x80);
+  while (bytes.length % 64 !== 56) bytes.push(0);
+  // 64-bit length. JS bitwise ops are 32-bit, so split high/low words.
+  const hi = Math.floor(bitLen / 0x100000000);
+  const lo = bitLen >>> 0;
+  bytes.push(
+    (hi >>> 24) & 0xff,
+    (hi >>> 16) & 0xff,
+    (hi >>> 8) & 0xff,
+    hi & 0xff,
+    (lo >>> 24) & 0xff,
+    (lo >>> 16) & 0xff,
+    (lo >>> 8) & 0xff,
+    lo & 0xff,
+  );
+
+  // Initial hash values (fractional parts of square roots of first 8 primes).
+  let h0 = 0x6a09e667,
+    h1 = 0xbb67ae85,
+    h2 = 0x3c6ef372,
+    h3 = 0xa54ff53a,
+    h4 = 0x510e527f,
+    h5 = 0x9b05688c,
+    h6 = 0x1f83d9ab,
+    h7 = 0x5be0cd19;
+
+  const w = new Uint32Array(64);
+
+  for (let offset = 0; offset < bytes.length; offset += 64) {
+    for (let i = 0; i < 16; i++) {
+      const j = offset + i * 4;
+      w[i] =
+        ((bytes[j] << 24) |
+          (bytes[j + 1] << 16) |
+          (bytes[j + 2] << 8) |
+          bytes[j + 3]) >>>
+        0;
+    }
+    for (let i = 16; i < 64; i++) {
+      const s0 =
+        rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >>> 3);
+      const s1 =
+        rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >>> 10);
+      w[i] = (w[i - 16] + s0 + w[i - 7] + s1) >>> 0;
+    }
+
+    let a = h0,
+      b = h1,
+      c = h2,
+      d = h3,
+      e = h4,
+      f = h5,
+      g = h6,
+      h = h7;
+
+    for (let i = 0; i < 64; i++) {
+      const S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      const ch = (e & f) ^ (~e & g);
+      const temp1 = (h + S1 + ch + K[i] + w[i]) >>> 0;
+      const S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (S0 + maj) >>> 0;
+
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temp1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+
+    h0 = (h0 + a) >>> 0;
+    h1 = (h1 + b) >>> 0;
+    h2 = (h2 + c) >>> 0;
+    h3 = (h3 + d) >>> 0;
+    h4 = (h4 + e) >>> 0;
+    h5 = (h5 + f) >>> 0;
+    h6 = (h6 + g) >>> 0;
+    h7 = (h7 + h) >>> 0;
+  }
+
+  const toHex = (n: number): string => (n >>> 0).toString(16).padStart(8, "0");
+  return (
+    toHex(h0) +
+    toHex(h1) +
+    toHex(h2) +
+    toHex(h3) +
+    toHex(h4) +
+    toHex(h5) +
+    toHex(h6) +
+    toHex(h7)
+  );
+}

--- a/packages/core/tests/crypto.test.ts
+++ b/packages/core/tests/crypto.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "bun:test";
+import { sha256Hex } from "../src/sha256";
+import { derivePlayerId, derivePlayerIdLegacy } from "../src/constants";
+
+describe("sha256Hex", () => {
+  // Canonical NIST/known test vectors.
+  it("hashes the empty string", () => {
+    expect(sha256Hex("")).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+  });
+
+  it("hashes 'abc'", () => {
+    expect(sha256Hex("abc")).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+  });
+
+  it("hashes a longer multi-block message", () => {
+    expect(
+      sha256Hex(
+        "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
+      ),
+    ).toBe(
+      "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
+    );
+  });
+
+  it("produces the same digest as the Web Crypto API (incl. UTF-8)", async () => {
+    const inputs = [
+      "",
+      "abc",
+      "the-quick-brown-fox",
+      "héllo 🎮", // 2-byte and 4-byte (surrogate pair) encodings
+      "x".repeat(1000), // multi-block
+    ];
+    for (const input of inputs) {
+      const data = new TextEncoder().encode(input);
+      const hash = await crypto.subtle.digest("SHA-256", data);
+      const expected = Array.from(new Uint8Array(hash))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+      expect(sha256Hex(input)).toBe(expected);
+    }
+  });
+});
+
+describe("derivePlayerId", () => {
+  const secret = "123e4567-e89b-12d3-a456-426614174000";
+
+  it("returns a stable 16-char hex id", async () => {
+    const id = await derivePlayerId(secret);
+    expect(id).toMatch(/^[0-9a-f]{16}$/);
+    expect(await derivePlayerId(secret)).toBe(id);
+  });
+
+  it("matches the first 16 hex chars of the SHA-256 digest", async () => {
+    const id = await derivePlayerId(secret);
+    expect(id).toBe(sha256Hex(secret).slice(0, 16));
+  });
+
+  it("does NOT leak the secret (differs from legacy truncation)", async () => {
+    const id = await derivePlayerId(secret);
+    const legacy = derivePlayerIdLegacy(secret);
+    expect(id).not.toBe(legacy);
+    // The derived id must not be a prefix of the raw secret.
+    expect(secret.replace(/-/g, "")).not.toStartWith(id);
+  });
+
+  it("is collision-resistant across different secrets", async () => {
+    const a = await derivePlayerId("aaaaaaaa-e89b-12d3-a456-426614174000");
+    const b = await derivePlayerId("bbbbbbbb-e89b-12d3-a456-426614174000");
+    expect(a).not.toBe(b);
+  });
+
+  it("uses the secure pure-JS fallback when crypto.subtle is unavailable (Hermes)", async () => {
+    const original = globalThis.crypto;
+    try {
+      // Simulate React Native / Hermes, where crypto.subtle is not exposed.
+      Object.defineProperty(globalThis, "crypto", {
+        value: undefined,
+        configurable: true,
+      });
+      const id = await derivePlayerId(secret);
+      // Must equal the real SHA-256 prefix — NOT the legacy secret truncation.
+      expect(id).toBe(sha256Hex(secret).slice(0, 16));
+      expect(id).not.toBe(derivePlayerIdLegacy(secret));
+    } finally {
+      Object.defineProperty(globalThis, "crypto", {
+        value: original,
+        configurable: true,
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`derivePlayerId` hashes the session secret with SHA-256 via the Web Crypto API (`crypto.subtle`). The host runs on **React Native / Hermes, which does not expose `crypto.subtle` by default**, and there is no polyfill in `@couch-kit/host` or the `init` scaffold.

As a result, in production the code silently fell back to `derivePlayerIdLegacy`, which is explicitly marked *"Insecure — exposes first 16 hex chars of secret"*. The public `playerId` broadcast in game state was therefore **the first half of the raw 32-hex session token**.

Confirmed Hermes lacks `crypto.subtle` (no native SubtleCrypto without a polyfill/native module).

## Fix

- Add a dependency-free pure-JS SHA-256 (`packages/core/src/sha256.ts`) that is **byte-for-byte compatible** with `crypto.subtle.digest("SHA-256", ...)`.
- Use it as the fallback in `derivePlayerId` instead of the insecure legacy truncation, so derived IDs are secure and identical across all host runtimes.
- `derivePlayerIdLegacy` is retained **only** for reconnect migration of players who joined under the old scheme (used by `HostSessionManager`).

## Tests

New `packages/core/tests/crypto.test.ts`:
- SHA-256 known vectors (empty, `abc`, multi-block).
- Parity with the Web Crypto API across ASCII, UTF-8 multi-byte + surrogate pairs, and multi-block inputs.
- `derivePlayerId` stability, correctness, collision-resistance, and **no secret leak**.
- Forces the `crypto.subtle`-unavailable path (simulated Hermes) and asserts the secure hash is used, not the legacy leak.

All 131 tests pass; lint, typecheck, and build are green.

## Compatibility

`patch` for `@couch-kit/core`. On Hermes hosts the derived `playerId` changes value, but IDs are per-session and host state resets on app restart; reconnect migration is preserved via the legacy lookup.