### PR TITLE
fix(host): reject client actions dispatched before JOIN

### DIFF
--- a/.changeset/reject-action-before-join.md
+++ b/.changeset/reject-action-before-join.md
@@ -1,0 +1,12 @@
+---
+"@couch-kit/host": patch
+---
+
+**Security:** Reject client ACTIONs from sockets that have not completed a JOIN.
+
+Previously an ACTION from a socket with no resolved player ID was dispatched with
+`playerId: undefined`, letting an un-joined client mutate game state. The host now
+rejects such actions with an `ERROR { code: "NOT_JOINED" }`.
+
+The internal-action injection guard and this new un-joined guard are extracted
+into a pure, unit-tested `authorizeClientAction` helper.

--- a/packages/host/src/action-authorization.ts
+++ b/packages/host/src/action-authorization.ts
@@ -1,0 +1,55 @@
+import { InternalActionTypes } from "@couch-kit/core";
+
+/** Error codes surfaced when a client ACTION is rejected before dispatch. */
+export type ActionRejectionCode = "FORBIDDEN_ACTION" | "NOT_JOINED";
+
+/** Outcome of authorizing an inbound client ACTION message. */
+export type ActionAuthorization =
+  | { kind: "allow"; playerId: string }
+  | { kind: "reject"; code: ActionRejectionCode; message: string };
+
+const INTERNAL_ACTION_TYPES = new Set<string>([
+  InternalActionTypes.HYDRATE,
+  InternalActionTypes.PLAYER_JOINED,
+  InternalActionTypes.PLAYER_LEFT,
+  InternalActionTypes.PLAYER_RECONNECTED,
+  InternalActionTypes.PLAYER_REMOVED,
+]);
+
+/**
+ * Decide whether an inbound client ACTION may be dispatched.
+ *
+ * Rejects, in order:
+ * - **Internal action types** — clients must not be able to inject framework
+ *   actions (`__HYDRATE__`, `__PLAYER_JOINED__`, etc.) to forge state.
+ * - **Un-joined sockets** — a socket with no resolved player ID never completed
+ *   a JOIN, so its actions have no owner and must not mutate state.
+ *
+ * The decision is pure so it can be unit-tested without a WebSocket or React.
+ *
+ * @param actionType - The `type` field of the client's action payload.
+ * @param resolvedPlayerId - The player ID cached for the socket at JOIN time, or
+ *   `undefined` if the socket has not joined.
+ */
+export function authorizeClientAction(
+  actionType: string,
+  resolvedPlayerId: string | undefined,
+): ActionAuthorization {
+  if (INTERNAL_ACTION_TYPES.has(actionType)) {
+    return {
+      kind: "reject",
+      code: "FORBIDDEN_ACTION",
+      message: "Internal action types cannot be dispatched by clients",
+    };
+  }
+
+  if (!resolvedPlayerId) {
+    return {
+      kind: "reject",
+      code: "NOT_JOINED",
+      message: "You must JOIN before dispatching actions",
+    };
+  }
+
+  return { kind: "allow", playerId: resolvedPlayerId };
+}

--- a/packages/host/src/provider.tsx
+++ b/packages/host/src/provider.tsx
@@ -27,6 +27,7 @@ import {
   HostSessionManager,
   type JoinSessionPayload,
 } from "./session-manager";
+import { authorizeClientAction } from "./action-authorization";
 import {
   BroadcastScheduler,
   DEFAULT_STATE_THROTTLE_MS,
@@ -283,28 +284,25 @@ export function GameHostProvider<S extends IGameState, A extends IAction>({
         }
 
         case MessageTypes.ACTION: {
-          // Only accept actions with a user-defined type string,
-          // reject internal action types to prevent injection.
           const actionPayload = message.payload as A;
-          if (
-            actionPayload.type === InternalActionTypes.HYDRATE ||
-            actionPayload.type === InternalActionTypes.PLAYER_JOINED ||
-            actionPayload.type === InternalActionTypes.PLAYER_LEFT ||
-            actionPayload.type === InternalActionTypes.PLAYER_RECONNECTED ||
-            actionPayload.type === InternalActionTypes.PLAYER_REMOVED
-          ) {
+
+          // Authorize before doing any work: reject client-injected internal
+          // action types and actions from sockets that never completed a JOIN.
+          const resolvedPlayerId =
+            sessionManager.current.getPlayerIdForSocket(socketId);
+          const auth = authorizeClientAction(
+            actionPayload.type,
+            resolvedPlayerId,
+          );
+          if (auth.kind === "reject") {
             if (configRef.current.debug)
               console.warn(
-                `[GameHost] Rejected internal action from ${socketId}:`,
+                `[GameHost] Rejected action from ${socketId} (${auth.code}):`,
                 actionPayload.type,
               );
             server.send(socketId, {
               type: MessageTypes.ERROR,
-              payload: {
-                code: "FORBIDDEN_ACTION",
-                message:
-                  "Internal action types cannot be dispatched by clients",
-              },
+              payload: { code: auth.code, message: auth.message },
             });
             return;
           }
@@ -323,10 +321,7 @@ export function GameHostProvider<S extends IGameState, A extends IAction>({
             return;
           }
 
-          // Use cached playerId (populated at JOIN time)
-          const resolvedPlayerId =
-            sessionManager.current.getPlayerIdForSocket(socketId);
-          dispatch({ ...actionPayload, playerId: resolvedPlayerId });
+          dispatch({ ...actionPayload, playerId: auth.playerId });
           actionQueue.current.push(actionPayload);
           break;
         }

--- a/packages/host/tests/action-authorization.test.ts
+++ b/packages/host/tests/action-authorization.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { InternalActionTypes } from "@couch-kit/core";
+import { authorizeClientAction } from "../src/action-authorization";
+
+describe("authorizeClientAction", () => {
+  test("allows a normal action from a joined socket", () => {
+    const result = authorizeClientAction("BUZZ", "player-123");
+    expect(result).toEqual({ kind: "allow", playerId: "player-123" });
+  });
+
+  test("rejects actions from a socket that never joined", () => {
+    const result = authorizeClientAction("BUZZ", undefined);
+    expect(result.kind).toBe("reject");
+    if (result.kind === "reject") {
+      expect(result.code).toBe("NOT_JOINED");
+      expect(result.message).toMatch(/JOIN/i);
+    }
+  });
+
+  test.each([
+    InternalActionTypes.HYDRATE,
+    InternalActionTypes.PLAYER_JOINED,
+    InternalActionTypes.PLAYER_LEFT,
+    InternalActionTypes.PLAYER_RECONNECTED,
+    InternalActionTypes.PLAYER_REMOVED,
+  ])("rejects injected internal action type %s", (type) => {
+    // Even with a valid playerId, internal action types are forbidden.
+    const result = authorizeClientAction(type, "player-123");
+    expect(result.kind).toBe("reject");
+    if (result.kind === "reject") {
+      expect(result.code).toBe("FORBIDDEN_ACTION");
+    }
+  });
+
+  test("prioritizes FORBIDDEN over NOT_JOINED for internal actions from un-joined sockets", () => {
+    const result = authorizeClientAction(
+      InternalActionTypes.HYDRATE,
+      undefined,
+    );
+    expect(result.kind).toBe("reject");
+    if (result.kind === "reject") {
+      expect(result.code).toBe("FORBIDDEN_ACTION");
+    }
+  });
+});


### PR DESCRIPTION
## Problem

In the host's ACTION handler, `getPlayerIdForSocket(socketId)` returns `undefined` for a socket that never sent a JOIN. The action was then dispatched as `{ ...actionPayload, playerId: undefined }`, letting an un-joined client mutate authoritative game state.

## Fix

- Reject ACTIONs from un-joined sockets with `ERROR { code: "NOT_JOINED" }`.
- Extract the existing internal-action injection guard **and** the new un-joined guard into a pure, testable `authorizeClientAction` helper (`packages/host/src/action-authorization.ts`), matching the codebase pattern of pulling logic out of `provider.tsx` (cf. `message-validation`, `rate-limiter`, `session-manager`).
- Authorization runs before rate-limiting and dispatch; valid joined actions are still rate-limited exactly as before.

## Tests

New `packages/host/tests/action-authorization.test.ts`:
- Allows normal actions from joined sockets.
- Rejects un-joined sockets with `NOT_JOINED`.
- Rejects every internal action type with `FORBIDDEN_ACTION`.
- Confirms `FORBIDDEN_ACTION` takes precedence over `NOT_JOINED`.

Host suite: 55 pass (8 new). Full repo: lint, typecheck, build, and all tests green.

`patch` changeset for `@couch-kit/host`.