### PR TITLE
fix(host): cap inbound WebSocket message size

### DIFF
--- a/.changeset/ws-payload-size-cap.md
+++ b/.changeset/ws-payload-size-cap.md
@@ -1,0 +1,11 @@
+---
+"@couch-kit/host": patch
+---
+
+**Security:** Cap the size of inbound client WebSocket messages.
+
+The host now discards any inbound frame larger than a configurable limit
+(default 256 KiB, via `maxMessageBytes`) before `JSON.parse`, bounding the
+memory a single malicious LAN client can force the host to allocate. The
+previous `maxFrameSize` option remains a documented no-op; this is a distinct
+application-level guard with a real default.

--- a/README.md
+++ b/README.md
@@ -394,3 +394,4 @@ Each consumer repo has a `renovate.json` scoped to the `@couch-kit/*` packages (
 
 - The controller URL is reachable to anyone on the same LAN. Don’t run this on untrusted Wi‑Fi.
 - `JOIN` requires a `secret` field — a persistent session token stored in the client's `localStorage`. The library uses it internally for session recovery. The raw secret is never broadcast to other clients; only a derived public `playerId` is shared in game state.
+- The host rejects internal action injection, rate-limits actions (60/sec), ignores actions from clients that haven't `JOIN`ed, and discards inbound messages larger than 256 KiB (configurable via `maxMessageBytes`) to bound memory usage.

--- a/packages/host/src/message-validation.ts
+++ b/packages/host/src/message-validation.ts
@@ -1,5 +1,41 @@
 import { MessageTypes, type ClientMessage } from "@couch-kit/core";
 
+/**
+ * Default maximum size (in bytes) of an inbound client message. Frames larger
+ * than this are discarded before `JSON.parse`, bounding the memory a single
+ * malicious LAN client can force the host to allocate. Generous enough for
+ * data-URI avatars in JOIN payloads while blocking multi-megabyte abuse.
+ */
+export const DEFAULT_MAX_MESSAGE_BYTES = 256 * 1024;
+
+/**
+ * Compute the UTF-8 byte length of a raw WebSocket frame payload.
+ *
+ * For binary frames the `ArrayBuffer.byteLength` is exact. For text frames the
+ * UTF-8 size is counted directly from the JS string without allocating an
+ * encoder buffer, so an oversized frame can be rejected cheaply.
+ */
+export function frameByteLength(data: string | ArrayBuffer): number {
+  if (typeof data !== "string") return data.byteLength;
+
+  let bytes = 0;
+  for (let i = 0; i < data.length; i++) {
+    const code = data.charCodeAt(i);
+    if (code < 0x80) {
+      bytes += 1;
+    } else if (code < 0x800) {
+      bytes += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      // High surrogate: a full pair encodes to 4 UTF-8 bytes.
+      bytes += 4;
+      i++; // Skip the paired low surrogate.
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
 type ClientMessageOf<TType extends ClientMessage["type"]> = Extract<
   ClientMessage,
   { type: TType }

--- a/packages/host/src/provider.tsx
+++ b/packages/host/src/provider.tsx
@@ -47,6 +47,11 @@ export interface GameHostConfig<S extends IGameState, A extends IAction> {
   disconnectTimeout?: number;
   /** State broadcast throttle interval in milliseconds (default: 33ms, ~30fps). */
   stateThrottleMs?: number;
+  /**
+   * Maximum size (in bytes) of an inbound client message. Frames larger than
+   * this are discarded before parsing (default: 256 KiB).
+   */
+  maxMessageBytes?: number;
   /** Called when a player successfully joins. */
   onPlayerJoined?: (playerId: string, name: string) => void;
   /** Called when a player disconnects. */
@@ -187,7 +192,11 @@ export function GameHostProvider<S extends IGameState, A extends IAction>({
 
   useEffect(() => {
     const port = config.wsPort || httpPort + DEFAULT_WS_PORT_OFFSET;
-    const server = new GameWebSocketServer({ port, debug: config.debug });
+    const server = new GameWebSocketServer({
+      port,
+      debug: config.debug,
+      maxMessageBytes: config.maxMessageBytes,
+    });
 
     // Start the WebSocket server asynchronously
     server.start().catch((error) => {

--- a/packages/host/src/websocket.ts
+++ b/packages/host/src/websocket.ts
@@ -12,10 +12,21 @@ import type {
 } from "react-native-nitro-http-server";
 import { EventEmitter } from "./event-emitter";
 import { generateId, DEFAULT_WS_PATH } from "@couch-kit/core";
+import {
+  DEFAULT_MAX_MESSAGE_BYTES,
+  frameByteLength,
+} from "./message-validation";
 
 export interface WebSocketConfig {
   port: number;
   debug?: boolean;
+  /**
+   * Maximum size (in bytes) of an inbound client message. Frames larger than
+   * this are discarded before parsing, bounding the memory a single client can
+   * force the host to allocate. Defaults to {@link DEFAULT_MAX_MESSAGE_BYTES}
+   * (256 KiB).
+   */
+  maxMessageBytes?: number;
   /**
    * @deprecated No effect. The underlying nitro-http WebSocket transport
    * manages frame sizing internally and this value is never read. This field
@@ -56,15 +67,18 @@ export class GameWebSocketServer extends EventEmitter<WebSocketServerEvents> {
   private clients: Map<string, WebSocketClient> = new Map();
   private port: number;
   private debug: boolean;
+  private maxMessageBytes: number;
 
   constructor(config: WebSocketConfig) {
     super();
     this.port = config.port;
     this.debug = !!config.debug;
-    // Only `port` and `debug` are honored. `maxFrameSize`, `keepaliveInterval`,
-    // and `keepaliveTimeout` are deprecated no-ops: the nitro-http WebSocket
-    // transport does not expose these knobs, so they are intentionally ignored
-    // (see the @deprecated tags on WebSocketConfig).
+    this.maxMessageBytes =
+      config.maxMessageBytes ?? DEFAULT_MAX_MESSAGE_BYTES;
+    // Only `port`, `debug`, and `maxMessageBytes` are honored. `maxFrameSize`,
+    // `keepaliveInterval`, and `keepaliveTimeout` are deprecated no-ops: the
+    // nitro-http WebSocket transport does not expose these knobs, so they are
+    // intentionally ignored (see the @deprecated tags on WebSocketConfig).
   }
 
   private log(...args: unknown[]) {
@@ -93,6 +107,16 @@ export class GameWebSocketServer extends EventEmitter<WebSocketServerEvents> {
 
         // Handle incoming messages
         ws.onmessage = (event: { data: string | ArrayBuffer }) => {
+          // Reject oversized frames before parsing to bound memory usage.
+          const size = frameByteLength(event.data);
+          if (size > this.maxMessageBytes) {
+            this.log(
+              `[WebSocket] Message from ${socketId} exceeds limit ` +
+                `(${size} > ${this.maxMessageBytes} bytes), discarding`,
+            );
+            return;
+          }
+
           try {
             const data =
               typeof event.data === "string"

--- a/packages/host/tests/message-validation.test.ts
+++ b/packages/host/tests/message-validation.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { MessageTypes } from "@couch-kit/core";
-import { isValidClientMessage } from "../src/message-validation";
+import {
+  isValidClientMessage,
+  frameByteLength,
+  DEFAULT_MAX_MESSAGE_BYTES,
+} from "../src/message-validation";
 
 describe("isValidClientMessage", () => {
   test("accepts valid client messages", () => {
@@ -63,5 +67,45 @@ describe("isValidClientMessage", () => {
     for (const message of invalidMessages) {
       expect(isValidClientMessage(message)).toBe(false);
     }
+  });
+});
+
+describe("frameByteLength", () => {
+  test("counts ASCII strings as one byte per character", () => {
+    expect(frameByteLength("")).toBe(0);
+    expect(frameByteLength("hello")).toBe(5);
+    expect(frameByteLength('{"type":"PING"}')).toBe(15);
+  });
+
+  test("counts multi-byte UTF-8 characters correctly", () => {
+    expect(frameByteLength("é")).toBe(2); // U+00E9 -> 2 bytes
+    expect(frameByteLength("€")).toBe(3); // U+20AC -> 3 bytes
+    expect(frameByteLength("🎮")).toBe(4); // surrogate pair -> 4 bytes
+    expect(frameByteLength("a🎮b")).toBe(6); // 1 + 4 + 1
+  });
+
+  test("matches the Web Crypto TextEncoder byte length", () => {
+    const encoder = new TextEncoder();
+    for (const input of ["", "abc", "héllo 🎮", "mixed €¢ 漢字 🀄"]) {
+      expect(frameByteLength(input)).toBe(encoder.encode(input).length);
+    }
+  });
+
+  test("uses byteLength directly for binary (ArrayBuffer) frames", () => {
+    const buf = new Uint8Array([1, 2, 3, 4, 5]).buffer;
+    expect(frameByteLength(buf)).toBe(5);
+    expect(frameByteLength(new ArrayBuffer(0))).toBe(0);
+  });
+
+  test("exposes a sane default cap that allows normal payloads but blocks abuse", () => {
+    expect(DEFAULT_MAX_MESSAGE_BYTES).toBe(256 * 1024);
+    const typicalJoin = JSON.stringify({
+      type: "JOIN",
+      payload: { name: "Alice", avatar: "🎮", secret: "x".repeat(36) },
+    });
+    expect(frameByteLength(typicalJoin)).toBeLessThan(DEFAULT_MAX_MESSAGE_BYTES);
+    expect(frameByteLength("x".repeat(1_000_000))).toBeGreaterThan(
+      DEFAULT_MAX_MESSAGE_BYTES,
+    );
   });
 });


### PR DESCRIPTION
## Problem

The host parsed every inbound client WebSocket frame with `JSON.parse` and no size limit. The rate limiter caps action *count* (60/sec) but not *size*, and the `maxFrameSize` option is a documented no-op. A single malicious LAN client could send arbitrarily large JSON frames and force the host to allocate unbounded memory (DoS).

## Fix

- Discard any inbound frame larger than `maxMessageBytes` (default **256 KiB**) **before** `JSON.parse`, in `GameWebSocketServer.onmessage`.
- Add a pure, testable `frameByteLength` helper (exact UTF-8 size for text frames, `byteLength` for binary) and `DEFAULT_MAX_MESSAGE_BYTES` in `message-validation.ts`.
- Expose `maxMessageBytes` on `WebSocketConfig` and thread it through `GameHostConfig`. Oversized frames are silently discarded (like malformed JSON) to avoid amplification.
- Only **inbound client→host** frames are capped; **host→client** state broadcasts are trusted and uncapped.

## Consumer compatibility (verified)

Checked buzz-tv-party-game, domino-party-game, and card-game-engine:
- All JOIN payloads use short emoji avatars (no `data:` URIs); actions are tiny (`{type:"BUZZ"}`, tile plays) — far under 256 KiB.
- Large card-game-engine state (rulesets/catalogs) is broadcast **host→client**, which is unaffected.
- Domino bots dispatch **host-side** and never send WS frames.

## Tests

New `frameByteLength` tests in `message-validation.test.ts`: ASCII, multi-byte UTF-8, surrogate pairs, binary frames, TextEncoder parity, and default-cap sanity (typical JOIN passes, 1 MB blocked). Host suite: 60 pass. Full repo lint/typecheck/build/test green.

`patch` changeset for `@couch-kit/host`. README Security Notes updated.