### PR TITLE
chore: add SECURITY.md and Renovate config for own deps

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+`couch-kit` builds **local multiplayer party games** where an Android TV host and
+phone controllers talk to each other over a **LAN** WebSocket connection. It is
+designed for a living-room threat model — everyone on the network is assumed to be
+a guest you invited — not for exposure to the public internet.
+
+## Supported Versions
+
+The project is pre-1.0. Security fixes are released only against the **latest
+published version** of each `@couch-kit/*` package on npm. Please upgrade to the
+newest release before reporting an issue.
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | ✅        |
+| older   | ❌        |
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, report privately through GitHub's private vulnerability reporting:
+
+1. Go to the [**Security** tab](https://github.com/faluciano/react-native-couch-kit/security).
+2. Click **Report a vulnerability** (or use this direct link:
+   <https://github.com/faluciano/react-native-couch-kit/security/advisories/new>).
+3. Describe the issue, the affected package(s) and version(s), and — if possible —
+   a minimal reproduction and the impact you believe it has.
+
+You should get an initial acknowledgement within **7 days**. Once a fix is ready it
+will be published to npm and disclosed via a GitHub Security Advisory, crediting the
+reporter unless anonymity is requested.
+
+## Scope
+
+The host is authoritative and already applies several hardening measures (see
+[Security Notes](README.md#security-notes) in the README):
+
+- Player IDs are derived from a per-client session secret with SHA-256; the raw
+  secret is never broadcast — only the derived public `playerId` is shared.
+- The host rejects injected internal action types, rate-limits actions (60/sec),
+  ignores actions from clients that haven't `JOIN`ed, and caps inbound WebSocket
+  messages (256 KiB by default, configurable via `maxMessageBytes`).
+
+Reports that fall **outside** the LAN party-game threat model — for example,
+attacks that assume the host is deliberately exposed to the public internet, or
+that require a malicious actor already on your trusted local network to reach a
+device they could compromise by other means — are still welcome, but may be
+documented as known limitations rather than patched.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":dependencyDashboard"],
+  "labels": ["dependencies"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "packageRules": [
+    {
+      "description": "Internal workspace packages are versioned by the changesets release pipeline, never by Renovate. Their package.json references use the workspace:* protocol and must stay untouched.",
+      "matchPackageNames": ["@couch-kit/*"],
+      "enabled": false
+    },
+    {
+      "description": "Group all non-major devDependency updates into a single PR and auto-merge once CI (lint, typecheck, build, test) passes.",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "dev dependencies",
+      "automerge": true
+    },
+    {
+      "description": "Auto-merge the weekly Bun lockfile refresh once CI passes.",
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "automerge": true
+    },
+    {
+      "description": "Hold every major update for manual review — these can carry breaking changes for consumers.",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Two production-hardening hygiene items from the readiness analysis (#7 + #8), both **root-level config/docs** (no changeset needed):

### `SECURITY.md`
- States the **LAN party-game threat model** (living-room, not public-internet).
- Supported versions: latest published `@couch-kit/*` only (pre-1.0).
- **Private vulnerability reporting** via GitHub Security Advisories (direct link included) instead of public issues, with a 7-day acknowledgement target.
- Recaps the existing host hardening (SHA-256 player IDs, internal-action rejection, 60/sec rate limit, un-joined action rejection, 256 KiB inbound cap) and links to the README Security Notes.

> Note: this enables the **Report a vulnerability** button only if *Private vulnerability reporting* is turned on under **Settings -> Code security**. Worth enabling if it isn't already.

### `renovate.json`
Keeps the **library's own** dependencies fresh (the consumer apps already use Renovate for `@couch-kit/*`; this covers this repo's TS/eslint/expo/etc.):
- **Disables** management of internal `@couch-kit/*` workspace packages — they're versioned by the changesets pipeline and their `workspace:*` references must stay untouched.
- Groups **non-major devDependency** updates into one PR and **auto-merges** after CI (lint/typecheck/build/test) passes.
- Weekly **Bun lockfile maintenance** (auto-merged on green).
- **Majors held** for manual review.
- Renovate (not Dependabot) because Dependabot doesn't regenerate Bun workspace lockfiles.

## Validation
- `renovate-config-validator` -> "Config validated successfully".
- Prettier clean; valid JSON.
- Config-only change; `changeset status` reports no packages to bump.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
