### PR TITLE
test(cli): cover commands and fix init/replay/flag arg forwarding

### DIFF
--- a/.changeset/cli-arg-forwarding-fix.md
+++ b/.changeset/cli-arg-forwarding-fix.md
@@ -1,0 +1,5 @@
+---
+"@couch-kit/cli": patch
+---
+
+**CLI improvements:** Fix argument forwarding from the top-level command to the lazily-loaded sub-commands. `couch-kit init <name>` now scaffolds into `<name>` instead of always creating a folder called `init`; `couch-kit replay <recording> <reducer>` no longer shifts its positional arguments; and positive boolean flags (`--host`, `--open`, `--snapshots`, `--json`) are now forwarded correctly instead of being silently dropped.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -27,9 +27,9 @@ program
     "-m, --manifest <path>",
     "Also write manifest to this path for import in app source",
   )
-  .action(async (options) => {
+  .action(async (_options, command) => {
     const { bundleCommand } = await import("./commands/bundle");
-    await bundleCommand.parseAsync(["bundle", ...reconstructArgs(options)], {
+    await bundleCommand.parseAsync(reconstructArgs(command), {
       from: "user",
     });
   });
@@ -40,12 +40,11 @@ program
   .option("-n, --count <number>", "Number of bots", "4")
   .option("-u, --url <url>", "WebSocket URL of host", "ws://localhost:8082")
   .option("-i, --interval <ms>", "Action interval in ms", "1000")
-  .action(async (options) => {
+  .action(async (_options, command) => {
     const { simulateCommand } = await import("./commands/simulate");
-    await simulateCommand.parseAsync(
-      ["simulate", ...reconstructArgs(options)],
-      { from: "user" },
-    );
+    await simulateCommand.parseAsync(reconstructArgs(command), {
+      from: "user",
+    });
   });
 
 program
@@ -54,7 +53,7 @@ program
   .argument("[name]", "Project name", "web-controller")
   .action(async (name) => {
     const { initCommand } = await import("./commands/init");
-    await initCommand.parseAsync(["init", name], { from: "user" });
+    await initCommand.parseAsync([name], { from: "user" });
   });
 
 program
@@ -64,12 +63,11 @@ program
   .argument("<reducer>", "Path to reducer module")
   .option("--snapshots", "Output intermediate state snapshots")
   .option("--json", "Output as formatted JSON")
-  .action(async (recording, reducer, options) => {
+  .action(async (recording, reducer, _options, command) => {
     const { replay } = await import("./commands/replay");
-    await replay.parseAsync(
-      ["replay", recording, reducer, ...reconstructArgs(options)],
-      { from: "user" },
-    );
+    await replay.parseAsync([recording, reducer, ...reconstructArgs(command)], {
+      from: "user",
+    });
   });
 
 program
@@ -78,29 +76,48 @@ program
   .option("-p, --port <port>", "Port number", "5173")
   .option("--host", "Expose to LAN")
   .option("--open", "Open browser automatically")
-  .action(async (options) => {
+  .action(async (_options, command) => {
     const { dev } = await import("./commands/dev");
-    await dev.parseAsync(["dev", ...reconstructArgs(options)], {
+    await dev.parseAsync(reconstructArgs(command), {
       from: "user",
     });
   });
 
 /**
- * Reconstruct CLI args from parsed options for re-parsing by the lazy-loaded command.
+ * Reconstruct the CLI args for a lazily-loaded sub-command from the values
+ * already parsed by its thin top-level proxy command.
  *
- * NOTE: Boolean options are assumed to use the negation pattern (--no-<x>).
- * Positive boolean flags (--verbose) will be silently dropped.
- * If adding positive boolean options, refactor to pass options directly instead.
+ * We reconstruct from each declared option's metadata (rather than
+ * guessing flag names from the option values) so that every option kind is
+ * forwarded with its correct flag:
+ *   - value options (`--port 5173`)   -> `--port 5173`
+ *   - positive booleans (`--open`)    -> emitted only when enabled
+ *   - negated booleans (`--no-build`) -> emitted only when disabled
+ *
+ * Positional arguments are forwarded separately by each command's action.
  */
-function reconstructArgs(options: Record<string, unknown>): string[] {
+function reconstructArgs(command: Command): string[] {
   const args: string[] = [];
-  for (const [key, value] of Object.entries(options)) {
-    if (typeof value === "boolean") {
-      if (!value) args.push(`--no-${key}`);
-    } else if (value !== undefined) {
-      args.push(`--${key}`, String(value));
+  const opts = command.opts();
+
+  for (const option of command.options) {
+    const value = opts[option.attributeName()];
+    if (value === undefined) continue;
+
+    if (option.negate) {
+      // e.g. `--no-build` (attribute "build", defaults true): forward the
+      // negated flag only when the user actually disabled it.
+      if (value === false) args.push(option.long ?? option.short ?? "");
+    } else if (option.isBoolean()) {
+      // Positive flag such as `--host`/`--open`/`--snapshots`/`--json`:
+      // forward it only when enabled.
+      if (value === true) args.push(option.long ?? option.short ?? "");
+    } else {
+      // Value-bearing option such as `--port`/`--source`.
+      args.push(option.long ?? option.short ?? "", String(value));
     }
   }
+
   return args;
 }
 

--- a/packages/cli/tests/bundle.test.ts
+++ b/packages/cli/tests/bundle.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test, beforeEach, afterEach, spyOn } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+class ExitError extends Error {
+  constructor(public code?: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+describe("bundle command error handling", () => {
+  let tmpDir: string;
+  let errors: string[];
+  let restore: (() => void)[];
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "couch-kit-bundle-err-"));
+    errors = [];
+    const errSpy = spyOn(console, "error").mockImplementation(
+      (...args: unknown[]) => {
+        errors.push(args.map(String).join(" "));
+      },
+    );
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new ExitError(code);
+    }) as never);
+    restore = [
+      () => errSpy.mockRestore(),
+      () => logSpy.mockRestore(),
+      () => warnSpy.mockRestore(),
+      () => exitSpy.mockRestore(),
+    ];
+  });
+
+  afterEach(() => {
+    restore.forEach((fn) => fn());
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("exits when there is no build output to bundle", async () => {
+    // Source dir exists but has no dist/ directory.
+    const sourceDir = path.join(tmpDir, "web-controller");
+    fs.mkdirSync(sourceDir, { recursive: true });
+
+    const { bundleCommand } = await import("../src/commands/bundle");
+
+    let thrown: unknown;
+    try {
+      await bundleCommand.parseAsync(
+        [
+          "--source",
+          sourceDir,
+          "--output",
+          path.join(tmpDir, "out"),
+          "--no-build",
+        ],
+        { from: "user" },
+      );
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(ExitError);
+    expect((thrown as ExitError).code).toBe(1);
+    expect(errors.join("\n")).toContain("Build output not found");
+  });
+});

--- a/packages/cli/tests/dev.test.ts
+++ b/packages/cli/tests/dev.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test, beforeEach, afterEach, spyOn } from "bun:test";
+
+class ExitError extends Error {
+  constructor(public code?: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+/**
+ * The CLI package deliberately does NOT depend on vite (it is a user-land
+ * dependency of the scaffolded project). So in this test environment
+ * `import("vite")` fails and the command must surface a helpful message and
+ * exit rather than crash — that is the branch exercised here.
+ */
+describe("dev command", () => {
+  let errors: string[];
+  let restore: (() => void)[];
+
+  beforeEach(() => {
+    errors = [];
+    const errSpy = spyOn(console, "error").mockImplementation(
+      (...args: unknown[]) => {
+        errors.push(args.map(String).join(" "));
+      },
+    );
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new ExitError(code);
+    }) as never);
+    restore = [
+      () => errSpy.mockRestore(),
+      () => logSpy.mockRestore(),
+      () => exitSpy.mockRestore(),
+    ];
+  });
+
+  afterEach(() => {
+    restore.forEach((fn) => fn());
+  });
+
+  test("exits with a helpful message when vite is not installed", async () => {
+    const { dev } = await import("../src/commands/dev");
+
+    let thrown: unknown;
+    try {
+      await dev.parseAsync(["dev"], { from: "user" });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(ExitError);
+    expect((thrown as ExitError).code).toBe(1);
+    expect(errors.join("\n")).toContain("Vite is not installed");
+  });
+});

--- a/packages/cli/tests/init.test.ts
+++ b/packages/cli/tests/init.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test, beforeEach, afterEach, spyOn } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+/**
+ * Sentinel thrown by the mocked process.exit so the command's `catch`
+ * stops executing (mirroring a real exit) and the test can assert on it.
+ */
+class ExitError extends Error {
+  constructor(public code?: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+describe("init command", () => {
+  let tmpDir: string;
+  let originalCwd: string;
+  let logs: string[];
+  let errors: string[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let restore: (() => void)[];
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "couch-kit-init-"));
+    process.chdir(tmpDir);
+
+    logs = [];
+    errors = [];
+    const logSpy = spyOn(console, "log").mockImplementation(
+      (...args: unknown[]) => {
+        logs.push(args.map(String).join(" "));
+      },
+    );
+    const errSpy = spyOn(console, "error").mockImplementation(
+      (...args: unknown[]) => {
+        errors.push(args.map(String).join(" "));
+      },
+    );
+    restore = [() => logSpy.mockRestore(), () => errSpy.mockRestore()];
+  });
+
+  afterEach(() => {
+    restore.forEach((fn) => fn());
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("scaffolds a complete Vite + React + TS project", async () => {
+    const { initCommand } = await import("../src/commands/init");
+    await initCommand.parseAsync(["my-controller"], { from: "user" });
+
+    const projectDir = path.join(tmpDir, "my-controller");
+    const expectedFiles = [
+      "package.json",
+      "tsconfig.json",
+      "tsconfig.node.json",
+      "vite.config.ts",
+      "index.html",
+      ".gitignore",
+      "src/main.tsx",
+      "src/App.tsx",
+      "src/index.css",
+      "src/reducer.ts",
+    ];
+    for (const file of expectedFiles) {
+      expect(
+        fs.existsSync(path.join(projectDir, file)),
+        `expected ${file} to be scaffolded`,
+      ).toBe(true);
+    }
+  });
+
+  test("writes a valid package.json wired to @couch-kit/client", async () => {
+    const { initCommand } = await import("../src/commands/init");
+    await initCommand.parseAsync(["my-controller"], { from: "user" });
+
+    const pkg = JSON.parse(
+      fs.readFileSync(
+        path.join(tmpDir, "my-controller", "package.json"),
+        "utf-8",
+      ),
+    );
+    expect(pkg.name).toBe("my-controller");
+    expect(pkg.type).toBe("module");
+    expect(pkg.dependencies).toHaveProperty("@couch-kit/client");
+    expect(pkg.scripts.dev).toBe("vite");
+    // tsconfig.json must be valid JSON too
+    expect(() =>
+      JSON.parse(
+        fs.readFileSync(
+          path.join(tmpDir, "my-controller", "tsconfig.json"),
+          "utf-8",
+        ),
+      ),
+    ).not.toThrow();
+  });
+
+  test("sample reducer references @couch-kit/core and handles SCORE", async () => {
+    const { initCommand } = await import("../src/commands/init");
+    await initCommand.parseAsync(["my-controller"], { from: "user" });
+
+    const reducer = fs.readFileSync(
+      path.join(tmpDir, "my-controller", "src", "reducer.ts"),
+      "utf-8",
+    );
+    expect(reducer).toContain('from "@couch-kit/core"');
+    expect(reducer).toContain('case "SCORE"');
+    expect(reducer).toContain("export const gameReducer");
+    expect(reducer).toContain("export const initialState");
+  });
+
+  test("defaults the project name to web-controller", async () => {
+    const { initCommand } = await import("../src/commands/init");
+    // No positional arg → commander applies the "web-controller" default.
+    await initCommand.parseAsync([], { from: "user" });
+
+    expect(fs.existsSync(path.join(tmpDir, "web-controller"))).toBe(true);
+  });
+
+  test("fails when the target directory already exists", async () => {
+    fs.mkdirSync(path.join(tmpDir, "taken"));
+
+    const exitSpy = spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new ExitError(code);
+    }) as never);
+    restore.push(() => exitSpy.mockRestore());
+
+    const { initCommand } = await import("../src/commands/init");
+
+    let thrown: unknown;
+    try {
+      await initCommand.parseAsync(["taken"], { from: "user" });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(ExitError);
+    expect((thrown as ExitError).code).toBe(1);
+    expect(errors.join("\n")).toContain("already exists");
+  });
+});

--- a/packages/cli/tests/replay.test.ts
+++ b/packages/cli/tests/replay.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test, beforeEach, afterEach, spyOn } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+class ExitError extends Error {
+  constructor(public code?: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+const RECORDING = {
+  initialState: { status: "lobby", players: {}, count: 0 },
+  actions: [
+    { action: { type: "INC" }, timestamp: 1000 },
+    { action: { type: "INC" }, timestamp: 2000 },
+    { action: { type: "INC" }, timestamp: 3000 },
+  ],
+  startTimestamp: 500,
+  endTimestamp: 3500,
+};
+
+const REDUCER_SOURCE = `export default function reducer(state, action) {
+  switch (action.type) {
+    case "INC":
+      return { ...state, count: (state.count ?? 0) + 1 };
+    default:
+      return state;
+  }
+}
+`;
+
+describe("replay command", () => {
+  let tmpDir: string;
+  let logs: string[];
+  let errors: string[];
+  let restore: (() => void)[];
+  let recordingPath: string;
+  let reducerPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "couch-kit-replay-"));
+    recordingPath = path.join(tmpDir, "recording.json");
+    reducerPath = path.join(tmpDir, "reducer.mjs");
+    fs.writeFileSync(recordingPath, JSON.stringify(RECORDING));
+    fs.writeFileSync(reducerPath, REDUCER_SOURCE);
+
+    logs = [];
+    errors = [];
+    const logSpy = spyOn(console, "log").mockImplementation(
+      (...args: unknown[]) => {
+        logs.push(args.map(String).join(" "));
+      },
+    );
+    const errSpy = spyOn(console, "error").mockImplementation(
+      (...args: unknown[]) => {
+        errors.push(args.map(String).join(" "));
+      },
+    );
+    restore = [() => logSpy.mockRestore(), () => errSpy.mockRestore()];
+  });
+
+  afterEach(() => {
+    restore.forEach((fn) => fn());
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Import the `replay` command and reset its option values to their defaults.
+   * Commander retains parsed option values on the (singleton) command instance
+   * between `parseAsync` calls; in a real CLI invocation each run is a fresh
+   * process, so we emulate that isolation here.
+   */
+  async function loadReplay() {
+    const { replay } = await import("../src/commands/replay");
+    replay.setOptionValue("json", false);
+    replay.setOptionValue("snapshots", false);
+    return replay;
+  }
+
+  function mockExit() {
+    const exitSpy = spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new ExitError(code);
+    }) as never);
+    restore.push(() => exitSpy.mockRestore());
+  }
+
+  test("--json prints a summary with the final state", async () => {
+    const replay = await loadReplay();
+    await replay.parseAsync([recordingPath, reducerPath, "--json"], {
+      from: "user",
+    });
+
+    const output = JSON.parse(logs.join("\n"));
+    expect(output.actionCount).toBe(3);
+    expect(output.duration).toBe(3000);
+    expect(output.finalState.count).toBe(3);
+    // Without --snapshots the JSON summary omits the snapshot array.
+    expect(output.snapshots).toBeUndefined();
+  });
+
+  test("--json --snapshots includes every intermediate snapshot", async () => {
+    const replay = await loadReplay();
+    await replay.parseAsync(
+      [recordingPath, reducerPath, "--json", "--snapshots"],
+      { from: "user" },
+    );
+
+    const output = JSON.parse(logs.join("\n"));
+    expect(Array.isArray(output.snapshots)).toBe(true);
+    expect(output.snapshots).toHaveLength(3);
+    expect(output.snapshots[2].state.count).toBe(3);
+  });
+
+  test("human-readable output reports the action count", async () => {
+    const replay = await loadReplay();
+    await replay.parseAsync([recordingPath, reducerPath], {
+      from: "user",
+    });
+
+    const text = logs.join("\n");
+    expect(text).toContain("Replayed 3 actions in 3000ms");
+    expect(text).toContain("Final state:");
+  });
+
+  test("accepts a reducer exported as a named 'reducer'", async () => {
+    const namedReducer = path.join(tmpDir, "named.mjs");
+    fs.writeFileSync(
+      namedReducer,
+      `export const reducer = (state, action) =>
+        action.type === "INC"
+          ? { ...state, count: (state.count ?? 0) + 1 }
+          : state;
+`,
+    );
+
+    const replay = await loadReplay();
+    await replay.parseAsync([recordingPath, namedReducer, "--json"], {
+      from: "user",
+    });
+
+    expect(JSON.parse(logs.join("\n")).finalState.count).toBe(3);
+  });
+
+  test("exits when the recording file is missing", async () => {
+    mockExit();
+    const replay = await loadReplay();
+
+    let thrown: unknown;
+    try {
+      await replay.parseAsync([path.join(tmpDir, "nope.json"), reducerPath], {
+        from: "user",
+      });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect((thrown as ExitError).code).toBe(1);
+    expect(errors.join("\n")).toContain("Recording file not found");
+  });
+
+  test("exits on an invalid recording format", async () => {
+    fs.writeFileSync(recordingPath, JSON.stringify({ not: "a recording" }));
+    mockExit();
+    const replay = await loadReplay();
+
+    let thrown: unknown;
+    try {
+      await replay.parseAsync([recordingPath, reducerPath], {
+        from: "user",
+      });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect((thrown as ExitError).code).toBe(1);
+    expect(errors.join("\n")).toContain("Invalid recording format");
+  });
+
+  test("exits when the reducer module exports no function", async () => {
+    const badReducer = path.join(tmpDir, "bad.mjs");
+    fs.writeFileSync(badReducer, `export const notAReducer = 42;\n`);
+    mockExit();
+    const replay = await loadReplay();
+
+    let thrown: unknown;
+    try {
+      await replay.parseAsync([recordingPath, badReducer], {
+        from: "user",
+      });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect((thrown as ExitError).code).toBe(1);
+    expect(errors.join("\n")).toContain("must export");
+  });
+});


### PR DESCRIPTION
## Summary

Fills the untested-CLI gap (item #4) with command-level tests — and in doing so uncovered and fixed **two real, user-facing bugs** in the top-level dispatcher (`packages/cli/src/index.ts`).

## Bugs fixed

The thin top-level commands lazily `import()` the real command modules and re-invoke them with `parseAsync(argv, { from: "user" })`. Two things were wrong:

1. **Command name consumed as a positional.** The dispatcher prepended the command name, e.g. `initCommand.parseAsync(["init", name], { from: "user" })`. With `from: "user"`, *every* token is an operand, so `[name]` bound to `"init"` and the real name was dropped as excess. Result:
   - `couch-kit init my-app` scaffolded a folder literally named **`init`**.
   - `couch-kit replay <recording> <reducer>` shifted its args → **`Error: Recording file not found: replay`**.

   Fixed by not prepending the command name and forwarding positionals explicitly.

2. **Positive boolean flags silently dropped.** `reconstructArgs` guessed flag names from option *values*, assuming the `--no-<x>` negation pattern. Positive flags (`--host`, `--open`, `--snapshots`, `--json`) were dropped entirely. It now reconstructs from each option's **metadata** (`option.negate` / `option.isBoolean()`), emitting value options, positive booleans, and negated booleans with their correct flags.

Verified end-to-end via the real CLI: `init my-app` → `my-app/`, `replay` reads the right files, `replay --json --snapshots` forwards both flags.

## Tests added
- **init** — full scaffold contents, valid `package.json` wired to `@couch-kit/client`, sample reducer references `@couch-kit/core`, default name, already-exists error.
- **replay** — `--json`, `--json --snapshots`, human-readable output, named `reducer` export, missing file, invalid format, non-function reducer.
- **dev** — exits with a helpful message when vite isn't installed.
- **bundle** — exits when there's no build output.

21 CLI tests pass; full suite (185) green; typecheck, lint, build clean. Changeset: `patch` under **CLI improvements**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
