### PR TITLE
chore: add community health files (CoC, issue/PR templates)

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,6 +1,6 @@
 You are working on couch-kit, a TypeScript framework for local multiplayer TV party games.
 
-Package manager: Bun (1.2.19). Never use npm/yarn/pnpm.
+Package manager: Bun (1.3.14). Never use npm/yarn/pnpm.
 Build: bun run build (core must build first)
 Test: bun run test
 Lint: bun run lint

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: 🐛 Bug report
+description: Report a reproducible problem in couch-kit
+labels: ["bug", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! Please search
+        [existing issues](https://github.com/faluciano/react-native-couch-kit/issues)
+        first to avoid duplicates.
+
+        ⚠️ **Do not report security vulnerabilities here.** Use
+        [private vulnerability reporting](https://github.com/faluciano/react-native-couch-kit/security/advisories/new)
+        instead.
+  - type: dropdown
+    id: package
+    attributes:
+      label: Affected package(s)
+      description: Which package(s) does this bug involve?
+      multiple: true
+      options:
+        - "@couch-kit/core"
+        - "@couch-kit/client"
+        - "@couch-kit/host"
+        - "@couch-kit/cli"
+        - "@couch-kit/devtools"
+        - Not sure / other
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps (or a link to a minimal repo) that reproduce the problem.
+      placeholder: |
+        1. Run `couch-kit init ...`
+        2. Start the host with ...
+        3. Join from a phone and ...
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Please provide relevant versions.
+      value: |
+        - couch-kit version(s):
+        - Bun version (`bun --version`):
+        - Host platform (Android TV / Fire TV / emulator + OS version):
+        - Controller device & browser:
+        - React Native / Expo version:
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Paste any relevant log output or screenshots. Log output is automatically formatted as code.
+      render: shell
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: This is not a security vulnerability (those are reported privately).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/faluciano/react-native-couch-kit/security/advisories/new
+    about: Please report security issues privately, not as public issues.
+  - name: 💬 Questions & discussion
+    url: https://github.com/faluciano/react-native-couch-kit/discussions
+    about: Ask questions and share ideas in Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,62 @@
+name: ✨ Feature request
+description: Suggest an idea or enhancement for couch-kit
+labels: ["enhancement", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Please search
+        [existing issues](https://github.com/faluciano/react-native-couch-kit/issues)
+        first to see if it has already been proposed.
+  - type: dropdown
+    id: package
+    attributes:
+      label: Affected package(s)
+      description: Which package(s) would this feature touch?
+      multiple: true
+      options:
+        - "@couch-kit/core"
+        - "@couch-kit/client"
+        - "@couch-kit/host"
+        - "@couch-kit/cli"
+        - "@couch-kit/devtools"
+        - New package / cross-cutting
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem are you trying to solve? What is the use case?
+      placeholder: "I'm building a party game where ... and I can't ..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the API, behavior, or change you'd like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or alternative designs you've thought about.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, sketches, or anything else that helps explain the request.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!--
+Thanks for contributing to couch-kit! Please fill out the sections below.
+Keep the title concise; use a conventional-commit style prefix if you can
+(e.g. `fix:`, `feat:`, `chore:`, `docs:`).
+-->
+
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Related issues
+
+<!-- e.g. Closes #123 -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation only
+- [ ] Chore / tooling / CI
+
+## Checklist
+
+- [ ] I read the [Contributing guide](../CONTRIBUTING.md).
+- [ ] Changes use **Bun** only (no npm/yarn/pnpm).
+- [ ] `bun run test`, `bun run typecheck`, `bun run lint`, and `bun run build` pass locally.
+- [ ] Tests were added or updated for the change (coverage floors in `bun run coverage` still hold).
+- [ ] A changeset is included for any change to published `packages/*` source (`bun run changeset`). Workflow/config/docs-only changes do not need one.
+- [ ] I did **not** edit `CHANGELOG.md` files or `workspace:*` references by hand.
+
+## Notes for reviewers
+
+<!-- Anything that needs extra attention, screenshots, testing instructions, etc. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 
 ## Build & Verify
 
-Package manager: **Bun** (pinned to 1.2.19 via `packageManager` field). Never use npm, yarn, or pnpm.
+Package manager: **Bun** (pinned to 1.3.14 via `packageManager` field). Never use npm, yarn, or pnpm.
 
 ```bash
 bun install        # install dependencies

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement privately through
+[GitHub's private vulnerability reporting](https://github.com/faluciano/react-native-couch-kit/security/advisories/new)
+or by contacting the maintainer, [@faluciano](https://github.com/faluciano).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,12 @@
 
 A TypeScript framework for Android TV party games using phones as controllers.
 
+This project has a [Code of Conduct](./CODE_OF_CONDUCT.md). By participating,
+you are expected to uphold it.
+
 ## Development Setup
 
-**Package manager:** Bun (v1.2.19)
+**Package manager:** Bun (v1.3.14)
 
 ```bash
 bun install        # install dependencies
@@ -18,12 +21,12 @@ bun run typecheck  # type-check
 
 Five packages under `packages/`:
 
-| Package             | Description                            |
-| ------------------- | -------------------------------------- |
-| `@couch-kit/core`   | Shared types, protocol, reducer        |
-| `@couch-kit/client` | React hooks for phone controllers      |
-| `@couch-kit/host`   | React Native TV host                   |
-| `@couch-kit/cli`    | CLI tools (bundle, simulate, scaffold) |
+| Package               | Description                                 |
+| --------------------- | ------------------------------------------- |
+| `@couch-kit/core`     | Shared types, protocol, reducer             |
+| `@couch-kit/client`   | React hooks for phone controllers           |
+| `@couch-kit/host`     | React Native TV host                        |
+| `@couch-kit/cli`      | CLI tools (bundle, simulate, scaffold)      |
 | `@couch-kit/devtools` | Debug overlay component for web controllers |
 
 ## Making Changes


### PR DESCRIPTION
## What & why

Final item of the production-readiness backlog (#9): add the standard **community health files** GitHub looks for, so the repo scores a full community profile and contributors get guided templates.

## Changes

- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1. Enforcement is routed to [private vulnerability reporting](https://github.com/faluciano/react-native-couch-kit/security/advisories/new) / the maintainer (@faluciano), consistent with `SECURITY.md`.
- **Issue forms** (`.github/ISSUE_TEMPLATE/`):
  - `bug_report.yml` — structured bug form with affected-package picker, repro steps, environment, and a "not a security issue" gate.
  - `feature_request.yml` — problem/proposal/alternatives form.
  - `config.yml` — disables blank issues; links security reporting and Discussions.
- **`PULL_REQUEST_TEMPLATE.md`** — checklist aligned to the repo workflow (Bun-only, test/typecheck/lint/build, `bun run coverage` floors, changeset rules, no hand-editing CHANGELOGs / `workspace:*`).
- **Docs refresh**: bumped the now-stale `Bun 1.2.19` references to `1.3.14` in `CONTRIBUTING.md`, `AGENTS.md`, and `.cursor/rules` (following the toolchain bump in #95), and linked the Code of Conduct from `CONTRIBUTING.md`.

## Notes
- No `packages/*` source changes → no changeset required.
- Prettier-clean; issue-form YAML validated.
