### PR TITLE
ci: test host against react-native peer-range boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        react-native: ["0.76.0", "0.83.2"]
+        # Boundaries of the host peerDependency range (react-native >=0.72.0):
+        # the supported floor and the current latest.
+        react-native: ["0.72.0", "0.86.0"]
     steps:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
@@ -81,8 +83,8 @@ jobs:
       - run: bun install
       - name: Install React Native ${{ matrix.react-native }}
         run: bun add --dev react-native@${{ matrix.react-native }} --cwd packages/host
-      - name: Typecheck with RN ${{ matrix.react-native }}
-        run: bun run typecheck
+      - name: Typecheck host with RN ${{ matrix.react-native }}
+        run: bun run --filter '@couch-kit/host' typecheck
 
   changesets:
     if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'


### PR DESCRIPTION
## What & why

The `typecheck-matrix` job pinned two **arbitrary interior** React Native versions (`0.76.0`, `0.83.2`) that matched neither end of `@couch-kit/host`'s support window:

- `host` declares `peerDependencies: react-native ">=0.72.0"`, but the floor was never tested — so the support claim was unverified.
- The high leg (`0.83.2`) was **below** the `0.86.0` default that the regular `lint`/`test`/`typecheck` jobs already cover, making it redundant/stale.

## Change

Test the actual **boundaries** of the peer range instead:

| Leg | Was | Now |
| --- | --- | --- |
| Low | 0.76.0 | **0.72.0** (peer floor) |
| High | 0.83.2 | **0.86.0** (current latest) |

Also scoped the check to `bun run --filter '@couch-kit/host' typecheck` — `host` is the only package that imports `react-native` (`Platform` in `src/assets.ts`), so each leg now exercises the RN-sensitive surface directly instead of re-typechecking the other four packages.

## Verification

Locally installed each boundary into `packages/host` and ran the host typecheck:
- ✅ `react-native@0.72.0` — typecheck passes (floor claim holds)
- ✅ `react-native@0.86.0` — typecheck passes

Workflow-only change → no changeset required.
