### PR TITLE
ci: skip the changeset gate on Renovate PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,13 @@ jobs:
       - name: Typecheck host with RN ${{ matrix.react-native }}
         run: bun run --filter '@couch-kit/host' typecheck
 
+  # Require a changeset on human PRs that touch published packages. Skipped for
+  # the automated Changesets "Version Packages" PR and for Renovate dependency
+  # PRs (a job skipped via `if:` counts as passing for branch protection). If a
+  # Renovate runtime-dependency bump should ship to consumers, add a changeset
+  # to that PR by hand.
   changesets:
-    if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
+    if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main' && !startsWith(github.head_ref, 'renovate/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Problem

Renovate dependency PRs keep failing the **`changesets`** CI job, requiring manual fixes on every one (e.g. #108 `jest v30`, #110 `react v19` — both currently red *only* on `changesets`, everything else green).

The job runs `changeset status --since=origin/main`, which errors whenever any `packages/*` file changes without a changeset. A Renovate bump to a dep in `packages/*/package.json` trips this every time — but automated dependency bumps shouldn't be forced to author a changeset.

## Fix

Skip the `changesets` job for `renovate/*` branches, mirroring the existing skip for the Changesets **"Version Packages"** branch:

```yaml
if: github.event_name == 'pull_request'
    && github.head_ref != 'changeset-release/main'
    && !startsWith(github.head_ref, 'renovate/')
```

A job skipped via `if:` is treated as a **passing** required check by branch protection (same mechanism the `changeset-release/main` skip already relies on), so Renovate PRs stop getting blocked. Human PRs are unaffected and still require a changeset.

**Tradeoff (documented in a code comment):** a Renovate runtime-dependency bump now won't be *forced* to include a changeset. If such a bump should ship to consumers, add a changeset to that PR by hand. Majors are held for manual review anyway, and most auto-merged Renovate updates are devDeps / GitHub Actions / lockfile refreshes that legitimately need no release.

## After merging

The two open PRs (#108, #110) need to pick up this workflow change — Renovate will rebase them automatically on its next run, or you can click **Update branch**. Once rebased, their `changesets` check will skip and they'll be mergeable.

Workflow-only change → no changeset required.
