### PR TITLE
ci: auto-deploy relay to Azure Container Apps via OIDC

### DIFF
--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -1,0 +1,54 @@
+name: Deploy Relay
+
+# Redeploys the game-agnostic relay (services/relay) to Azure Container Apps.
+# Auth is via GitHub OIDC federated credentials — no stored Azure passwords,
+# same philosophy as the npm Trusted Publishing used by release.yml.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "services/relay/**"
+      - ".github/workflows/deploy-relay.yml"
+  workflow_dispatch:
+
+permissions:
+  id-token: write # required to request the OIDC token for azure/login
+  contents: read
+
+concurrency:
+  group: deploy-relay
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy to Azure Container Apps
+        uses: azure/cli@v2
+        with:
+          azcliversion: latest
+          inlineScript: |
+            az config set extension.use_dynamic_install=yes_without_prompt
+            az containerapp up \
+              --name couch-kit-relay \
+              --resource-group couch-kit-rg \
+              --location eastus \
+              --source services/relay \
+              --ingress external \
+              --target-port 8787
+            # In-memory rooms: keep a single always-on replica.
+            az containerapp update \
+              --name couch-kit-relay \
+              --resource-group couch-kit-rg \
+              --min-replicas 1 \
+              --max-replicas 1


### PR DESCRIPTION
Adds CI/CD for the relay (`services/relay`), which is currently deployed manually.

## What it does
- **Trigger:** push to `main` touching `services/relay/**` (or manual `workflow_dispatch`).
- **Auth:** GitHub **OIDC federated credentials** — no Azure passwords stored in GitHub. Same philosophy as the npm Trusted Publishing in `release.yml`.
- **Deploy:** `az containerapp up --source services/relay` rebuilds the image (cloud build) and rolls the app, then pins it to a single always-on replica (in-memory rooms).

## One-time setup already done
- Azure AD app `couch-kit-relay-github-oidc` + service principal, with a federated credential bound to `repo:faluciano/react-native-couch-kit:ref:refs/heads/main`.
- Repo secrets `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` (OIDC identifiers, not passwords).
- **Pending:** `Contributor` role for the SP on the `couch-kit-rg` resource group (scoped to just that RG). The workflow won't deploy until that grant is in place.

## Current state
The relay is already live (manually deployed) at
`couch-kit-relay.icycliff-4c194e2e.eastus.azurecontainerapps.io` — `/healthz` 200, and live `wss://` routing verified end-to-end. This PR makes future `services/relay` changes redeploy automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)