### PR TITLE
feat(relay): abuse-mitigation limits for the public endpoint

### DIFF
--- a/services/relay/README.md
+++ b/services/relay/README.md
@@ -21,6 +21,31 @@ bun test             # routing unit tests
 
 `GET /healthz` returns `200 ok` for health probes.
 
+## Abuse mitigation
+
+The relay is a public endpoint, so it bounds the blast radius of a hostile
+client without any external dependency (all limits are in-memory, per process,
+matching the single-instance model). Defaults are generous for party-game scale:
+
+| Limit                          | Default | Env override             | On breach                                  |
+| ------------------------------ | ------- | ------------------------ | ------------------------------------------ |
+| Messages / connection / second | 30      | _(code: `messagesPerWindow`)_ | `RATE_LIMITED` error, then socket closed (`1008`) |
+| Concurrent rooms               | 1000    | _(code: `maxRooms`)_     | `SERVER_BUSY` error on `CREATE_ROOM`       |
+| Players per room               | 16      | _(code: `maxPlayersPerRoom`)_ | `ROOM_FULL` error on `JOIN_ROOM`      |
+| Concurrent connections / IP    | 50      | `MAX_CONNECTIONS_PER_IP` | `429` on upgrade                           |
+| Message size                   | 256 KiB | _(code: `MAX_MESSAGE_BYTES`)_ | `MESSAGE_TOO_LARGE` error             |
+
+Set `ALLOWED_ORIGINS` (comma-separated) to reject WebSocket upgrades from other
+origins with `403`; unset (the default) allows any origin, since displays run on
+varying Vercel URLs. The rate/room/player limits are constructor options on
+`RelayRooms` (see `DEFAULT_LIMITS`); the connection-per-IP cap and origin
+allowlist are read from env in `server.ts`.
+
+Room codes are chosen by the display, not the relay, so they are only as
+unguessable as the client makes them; the per-connection rate limit plus
+per-IP cap are what throttle brute-force `JOIN_ROOM` scanning. Server-generated
+codes and auth tokens remain future work.
+
 ## Protocol (summary)
 
 Clients speak JSON. `data` is an opaque Couch Kit message string.

--- a/services/relay/src/rooms.ts
+++ b/services/relay/src/rooms.ts
@@ -32,10 +32,35 @@ export const RelayErrorCodes = {
   NOT_IN_ROOM: "NOT_IN_ROOM",
   MESSAGE_TOO_LARGE: "MESSAGE_TOO_LARGE",
   MALFORMED: "MALFORMED",
+  RATE_LIMITED: "RATE_LIMITED",
+  SERVER_BUSY: "SERVER_BUSY",
 } as const;
 
 /** Matches `@couch-kit/runtime`'s `DEFAULT_MAX_MESSAGE_BYTES`. */
 export const MAX_MESSAGE_BYTES = 256 * 1024;
+
+/**
+ * Abuse-mitigation limits for a public relay. All in-memory and per-process,
+ * matching the single-instance deployment model. Defaults are generous for
+ * party-game scale while bounding the blast radius of a hostile client.
+ */
+export interface RelayLimits {
+  /** Max concurrent rooms across the process (memory bound). */
+  maxRooms: number;
+  /** Max players (phones) per room, excluding the host. */
+  maxPlayersPerRoom: number;
+  /** Messages allowed per connection within {@link RelayLimits.rateWindowMs}. */
+  messagesPerWindow: number;
+  /** Sliding-window length for the per-connection message rate limit, in ms. */
+  rateWindowMs: number;
+}
+
+export const DEFAULT_LIMITS: RelayLimits = {
+  maxRooms: 1000,
+  maxPlayersPerRoom: 16,
+  messagesPerWindow: 30,
+  rateWindowMs: 1000,
+};
 
 /** UTF-8 byte length of a string (Node/Bun `Buffer` or `TextEncoder`). */
 export function byteLength(data: string): number {
@@ -67,16 +92,35 @@ interface Membership {
 export class RelayRooms {
   private readonly rooms = new Map<string, Room>();
   private readonly membership = new Map<string, Membership>();
+  /** Sliding-window message timestamps per connection id (rate limiting). */
+  private readonly rate = new Map<string, number[]>();
+  private readonly limits: RelayLimits;
+  private readonly now: () => number;
+
+  constructor(limits: Partial<RelayLimits> = {}, now: () => number = Date.now) {
+    this.limits = { ...DEFAULT_LIMITS, ...limits };
+    this.now = now;
+  }
 
   get roomCount(): number {
     return this.rooms.size;
   }
 
-  /** Route one raw inbound message from `conn`. */
-  handleMessage(conn: RelayConnection, raw: string): void {
+  /**
+   * Route one raw inbound message from `conn`.
+   *
+   * @returns `false` when the connection has abused the rate limit and the
+   *   transport should close it; `true` to keep it open.
+   */
+  handleMessage(conn: RelayConnection, raw: string): boolean {
+    if (!this.allow(conn.id)) {
+      this.sendError(conn, RelayErrorCodes.RATE_LIMITED, "Too many messages");
+      return false;
+    }
+
     if (byteLength(raw) > MAX_MESSAGE_BYTES) {
       this.sendError(conn, RelayErrorCodes.MESSAGE_TOO_LARGE, "Message too large");
-      return;
+      return true;
     }
 
     let msg: { type?: string; roomId?: string; to?: string; data?: string };
@@ -84,7 +128,7 @@ export class RelayRooms {
       msg = JSON.parse(raw);
     } catch {
       this.sendError(conn, RelayErrorCodes.MALFORMED, "Invalid JSON");
-      return;
+      return true;
     }
 
     switch (msg.type) {
@@ -100,10 +144,26 @@ export class RelayRooms {
       default:
         this.sendError(conn, RelayErrorCodes.MALFORMED, "Unknown message type");
     }
+    return true;
+  }
+
+  /**
+   * Sliding-window rate limit. Records this message's timestamp and returns
+   * `false` once a connection exceeds {@link RelayLimits.messagesPerWindow}
+   * within {@link RelayLimits.rateWindowMs}.
+   */
+  private allow(id: string): boolean {
+    const t = this.now();
+    const cutoff = t - this.limits.rateWindowMs;
+    const hits = (this.rate.get(id) ?? []).filter((ts) => ts > cutoff);
+    hits.push(t);
+    this.rate.set(id, hits);
+    return hits.length <= this.limits.messagesPerWindow;
   }
 
   /** Clean up a closed connection and notify its room. */
   handleClose(conn: RelayConnection): void {
+    this.rate.delete(conn.id);
     const mem = this.membership.get(conn.id);
     if (!mem) return;
     this.membership.delete(conn.id);
@@ -136,6 +196,10 @@ export class RelayRooms {
       this.sendError(conn, RelayErrorCodes.ROOM_EXISTS, "Room already exists");
       return;
     }
+    if (this.rooms.size >= this.limits.maxRooms) {
+      this.sendError(conn, RelayErrorCodes.SERVER_BUSY, "Too many rooms");
+      return;
+    }
     this.rooms.set(roomId, { host: conn, players: new Map() });
     this.membership.set(conn.id, { roomId, role: "host" });
     this.send(conn, {
@@ -153,6 +217,10 @@ export class RelayRooms {
     const room = this.rooms.get(roomId);
     if (!room) {
       this.sendError(conn, RelayErrorCodes.ROOM_NOT_FOUND, "Room not found");
+      return;
+    }
+    if (room.players.size >= this.limits.maxPlayersPerRoom) {
+      this.sendError(conn, RelayErrorCodes.ROOM_FULL, "Room is full");
       return;
     }
     room.players.set(conn.id, conn);

--- a/services/relay/src/server.ts
+++ b/services/relay/src/server.ts
@@ -9,11 +9,34 @@ import { RelayRooms, type RelayConnection } from "./rooms";
 
 interface SocketData {
   id: string;
+  ip: string;
   conn: RelayConnection | null;
 }
 
 const rooms = new RelayRooms();
 const port = Number(process.env.PORT ?? 8787);
+
+/**
+ * Optional origin allowlist. Set `ALLOWED_ORIGINS` (comma-separated) to reject
+ * WebSocket upgrades from other origins; unset means allow any origin (the
+ * default, since displays run on varying Vercel URLs).
+ */
+const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? "")
+  .split(",")
+  .map((o) => o.trim())
+  .filter(Boolean);
+
+/** Max concurrent connections per client IP (socket-exhaustion bound). */
+const maxConnectionsPerIp = Number(process.env.MAX_CONNECTIONS_PER_IP ?? 50);
+
+/** Live connection count per IP, used to cap concurrent sockets. */
+const ipCounts = new Map<string, number>();
+
+function originAllowed(req: Request): boolean {
+  if (allowedOrigins.length === 0) return true;
+  const origin = req.headers.get("origin");
+  return origin !== null && allowedOrigins.includes(origin);
+}
 
 const server = Bun.serve<SocketData, undefined>({
   port,
@@ -22,8 +45,18 @@ const server = Bun.serve<SocketData, undefined>({
     if (url.pathname === "/healthz") {
       return new Response("ok", { status: 200 });
     }
+
+    if (!originAllowed(req)) {
+      return new Response("Forbidden origin", { status: 403 });
+    }
+
+    const ip = server.requestIP(req)?.address ?? "unknown";
+    if ((ipCounts.get(ip) ?? 0) >= maxConnectionsPerIp) {
+      return new Response("Too many connections", { status: 429 });
+    }
+
     const upgraded = server.upgrade(req, {
-      data: { id: crypto.randomUUID(), conn: null },
+      data: { id: crypto.randomUUID(), ip, conn: null },
     });
     if (upgraded) return undefined;
     return new Response("Couch Kit relay", { status: 200 });
@@ -31,16 +64,22 @@ const server = Bun.serve<SocketData, undefined>({
   websocket: {
     maxPayloadLength: 512 * 1024,
     open(ws) {
+      ipCounts.set(ws.data.ip, (ipCounts.get(ws.data.ip) ?? 0) + 1);
       ws.data.conn = { id: ws.data.id, send: (data: string) => ws.send(data) };
     },
     message(ws, message) {
       if (!ws.data.conn) return;
-      rooms.handleMessage(
+      const keepOpen = rooms.handleMessage(
         ws.data.conn,
         typeof message === "string" ? message : message.toString(),
       );
+      // A connection that trips the rate limit is dropped to shed abusive load.
+      if (!keepOpen) ws.close(1008, "Rate limited");
     },
     close(ws) {
+      const next = (ipCounts.get(ws.data.ip) ?? 1) - 1;
+      if (next <= 0) ipCounts.delete(ws.data.ip);
+      else ipCounts.set(ws.data.ip, next);
       if (ws.data.conn) rooms.handleClose(ws.data.conn);
     },
   },

--- a/services/relay/tests/rooms.test.ts
+++ b/services/relay/tests/rooms.test.ts
@@ -162,4 +162,70 @@ describe("RelayRooms", () => {
     rooms.handleMessage(c, "{not json");
     expect(c.sent[0].code).toBe(RelayErrorCodes.MALFORMED);
   });
+
+  test("handleMessage returns true for well-behaved traffic", () => {
+    const rooms = new RelayRooms();
+    const host = conn("h");
+    const keepOpen = rooms.handleMessage(
+      host,
+      JSON.stringify({ type: "CREATE_ROOM", roomId: "R" }),
+    );
+    expect(keepOpen).toBe(true);
+  });
+
+  test("exceeding the message rate limit errors and signals disconnect", () => {
+    const rooms = new RelayRooms({ messagesPerWindow: 3, rateWindowMs: 1000 });
+    const c = conn("c");
+    // Unknown-type messages still count toward the rate limit.
+    const noop = JSON.stringify({ type: "NOPE" });
+    expect(rooms.handleMessage(c, noop)).toBe(true);
+    expect(rooms.handleMessage(c, noop)).toBe(true);
+    expect(rooms.handleMessage(c, noop)).toBe(true);
+    // 4th within the window trips the limit.
+    expect(rooms.handleMessage(c, noop)).toBe(false);
+    expect(c.sent.at(-1).code).toBe(RelayErrorCodes.RATE_LIMITED);
+  });
+
+  test("rate limit window slides as time advances", () => {
+    let t = 0;
+    const rooms = new RelayRooms(
+      { messagesPerWindow: 2, rateWindowMs: 1000 },
+      () => t,
+    );
+    const c = conn("c");
+    const noop = JSON.stringify({ type: "NOPE" });
+    expect(rooms.handleMessage(c, noop)).toBe(true);
+    expect(rooms.handleMessage(c, noop)).toBe(true);
+    t = 1001; // old hits fall out of the window
+    expect(rooms.handleMessage(c, noop)).toBe(true);
+  });
+
+  test("room creation is capped at maxRooms", () => {
+    const rooms = new RelayRooms({ maxRooms: 1 });
+    rooms.handleMessage(conn("h1"), JSON.stringify({ type: "CREATE_ROOM", roomId: "A" }));
+    const h2 = conn("h2");
+    rooms.handleMessage(h2, JSON.stringify({ type: "CREATE_ROOM", roomId: "B" }));
+    expect(h2.sent[0].code).toBe(RelayErrorCodes.SERVER_BUSY);
+    expect(rooms.roomCount).toBe(1);
+  });
+
+  test("joining a full room is rejected with ROOM_FULL", () => {
+    const rooms = new RelayRooms({ maxPlayersPerRoom: 1 });
+    rooms.handleMessage(conn("h"), JSON.stringify({ type: "CREATE_ROOM", roomId: "R" }));
+    rooms.handleMessage(conn("p1"), JSON.stringify({ type: "JOIN_ROOM", roomId: "R" }));
+    const p2 = conn("p2");
+    rooms.handleMessage(p2, JSON.stringify({ type: "JOIN_ROOM", roomId: "R" }));
+    expect(p2.sent[0].code).toBe(RelayErrorCodes.ROOM_FULL);
+  });
+
+  test("closing a connection clears its rate-limit state", () => {
+    const rooms = new RelayRooms({ messagesPerWindow: 2, rateWindowMs: 1000 });
+    const c = conn("c");
+    const noop = JSON.stringify({ type: "NOPE" });
+    rooms.handleMessage(c, noop);
+    rooms.handleMessage(c, noop);
+    rooms.handleClose(c);
+    // Fresh budget after reconnect (same id): first message is allowed again.
+    expect(rooms.handleMessage(c, noop)).toBe(true);
+  });
 });


### PR DESCRIPTION
The relay is a public, single-instance, in-memory WebSocket endpoint. This adds a **dependency-free hardening layer** that bounds the blast radius of a hostile client, without changing behavior for legitimate party-game traffic (defaults are generous).

## What's added
| Limit | Default | Override | On breach |
| --- | --- | --- | --- |
| Messages / connection / second | 30 | `messagesPerWindow` | `RATE_LIMITED` + socket close (1008) |
| Concurrent rooms | 1000 | `maxRooms` | `SERVER_BUSY` on CREATE_ROOM |
| Players per room | 16 | `maxPlayersPerRoom` | `ROOM_FULL` on JOIN_ROOM |
| Connections / IP | 50 | `MAX_CONNECTIONS_PER_IP` env | `429` on upgrade |
| Origin | any | `ALLOWED_ORIGINS` env | `403` on upgrade |

The per-connection rate limit + per-IP cap are also what throttle **brute-force `JOIN_ROOM` code scanning** (room codes are client-chosen, so the relay can't enforce their randomness — server-generated codes/auth remain future work, noted in the README).

## Design
- Rate/room/player limits live in the **pure, testable** `RelayRooms` core with an **injectable clock**; the IP cap and origin check live in `server.ts` (the socket layer).
- `handleMessage` now returns whether to keep the socket open; the server closes abusive connections.
- Defaults preserve current behavior: no origin restriction, caps far above party scale.

## Verification
- `bun test` — 17 pass (6 new: rate limit trip, sliding window, room cap, room-full, keep-open contract, rate-state cleanup on close).
- Booted the server and ran a live CREATE_ROOM → JOIN_ROOM flow through the new origin/IP path — unaffected. `/healthz` still 200.

Follow-ups (unchanged): server-generated room codes, auth tokens, reconnect across restarts, multi-instance backplane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)