### PR TITLE
fix(display): empty published bundle (0.1.0 shipped no code)

### DIFF
--- a/.changeset/fix-display-bundle.md
+++ b/.changeset/fix-display-bundle.md
@@ -1,0 +1,11 @@
+---
+"@couch-kit/display": patch
+---
+
+**Bundle & tree-shaking**
+
+- Fix an empty published `dist/index.js`. With `sideEffects: false`, a named
+  re-export barrel (`export { RelayDisplayHost } from …`) let bun's bundler
+  tree-shake the sole class out of the built entry, so `0.1.0` shipped a bundle
+  with no implementation. Use an `export *` barrel and add a post-build guard
+  that fails if `RelayDisplayHost` is missing from the output.

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -43,7 +43,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir ./dist --target browser --external @couch-kit/core --external @couch-kit/runtime --external @couch-kit/client && tsc -p tsconfig.build.json",
+    "build": "bun build ./src/index.ts --outdir ./dist --target browser --external @couch-kit/core --external @couch-kit/runtime --external @couch-kit/client && tsc -p tsconfig.build.json && bun run verify-build",
+    "verify-build": "node -e \"if(!require('fs').readFileSync('./dist/index.js','utf8').includes('class RelayDisplayHost'))throw new Error('dist/index.js is missing RelayDisplayHost — empty bundle');\"",
     "prepublishOnly": "bun run build",
     "test": "bun test",
     "lint": "eslint src/",

--- a/packages/display/src/index.ts
+++ b/packages/display/src/index.ts
@@ -1,4 +1,4 @@
-export {
-  RelayDisplayHost,
-  type RelayDisplayHostOptions,
-} from "./relay-display-host";
+// A single `export *` barrel: a named re-export (`export { X } from`) combined
+// with `sideEffects: false` lets bun's bundler tree-shake the sole class out of
+// the built entry, publishing an empty `dist/index.js`. `export *` keeps it.
+export * from "./relay-display-host";


### PR DESCRIPTION
`@couch-kit/display@0.1.0` published a **31-byte `dist/index.js` with no implementation**. With `sideEffects: false`, the named re-export barrel (`export { RelayDisplayHost } from "./relay-display-host"`) let bun's bundler tree-shake the sole class out of the built entry. Consumers importing the package then failed at their vite build (rollup parsing the source fallback).

## Fix
- `src/index.ts` → `export *` barrel (keeps `sideEffects: false` for consumer tree-shaking; sidesteps the DCE).
- Add a `verify-build` post-build guard: fails if `dist/index.js` doesn't contain `class RelayDisplayHost`, so an empty bundle can never publish again.

Rebuilt locally: `dist/index.js` is 2.6 KB with the class; guard passes. Ships as `@couch-kit/display@0.1.1` (0.1.0 is immutable). Consumers on `^0.1.0` pick up 0.1.1 automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)