### PR TITLE
fix(display): NodeNext consumers can't import RelayDisplayHost

### DIFF
--- a/.changeset/display-nodenext-export.md
+++ b/.changeset/display-nodenext-export.md
@@ -1,0 +1,11 @@
+---
+"@couch-kit/display": patch
+---
+
+**Bundle & tree-shaking**
+
+- Fix `RelayDisplayHost` resolving as "not exported" for consumers on
+  `moduleResolution: NodeNext`/`Node16`. The package is `type: module`, so the
+  emitted `.d.ts` is read in strict-ESM mode where an extensionless relative
+  re-export (`export * from "./relay-display-host"`) is not resolved. Add the
+  `.js` extension to the barrel specifier, matching the other ESM packages.

--- a/packages/display/src/index.ts
+++ b/packages/display/src/index.ts
@@ -1,4 +1,6 @@
-// A single `export *` barrel: a named re-export (`export { X } from`) combined
-// with `sideEffects: false` lets bun's bundler tree-shake the sole class out of
-// the built entry, publishing an empty `dist/index.js`. `export *` keeps it.
-export * from "./relay-display-host";
+// Use an `export *` barrel (a named `export { X } from` lets bun tree-shake the
+// sole class out under `sideEffects: false`, publishing an empty bundle) AND a
+// `.js` extension on the specifier: the package is `type: module`, so consumers
+// on `moduleResolution: NodeNext` resolve the emitted `.d.ts` in strict-ESM mode
+// and an extensionless re-export fails to find `relay-display-host.d.ts`.
+export * from "./relay-display-host.js";


### PR DESCRIPTION
`@couch-kit/display` is `type: module`, so its published `.d.ts` is resolved in **strict-ESM mode** by any consumer using `moduleResolution: NodeNext`/`Node16`. In that mode the extensionless barrel re-export `export * from "./relay-display-host"` doesn't resolve, so `RelayDisplayHost` shows up as **not exported** (with cascading `unknown` types).

Vite/bundler-resolution consumers (Buzz) were unaffected, which is why 0.1.0/0.1.1 looked fine — the card-game-engine display app (NodeNext) surfaced it.

## Fix
- `src/index.ts`: `export * from "./relay-display-host.js"` (add the `.js` extension, matching `@couch-kit/runtime`/`core`). Emitted `lib/index.d.ts` now resolves under NodeNext; bundle still contains the class (guard passes).

Ships as `0.1.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)