### PR TITLE
perf(relay): compress payloads and scale to zero when idle

### DIFF
--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -46,9 +46,22 @@ jobs:
               --source services/relay \
               --ingress external \
               --target-port 8787
-            # In-memory rooms: keep a single always-on replica.
+            # Rooms are in-memory, so the relay must never run more than one
+            # replica — a second replica would own a disjoint set of rooms and
+            # silently split games in half.
+            #
+            # min-replicas 0 (scale to zero when idle) is safe *because* rooms
+            # are ephemeral: a replica only stops once no WebSocket is open, and
+            # an open socket is exactly what a live game is. The HTTP scaler
+            # counts held WebSocket connections as active requests, so a table
+            # with players on it keeps the replica alive. The cost is a cold
+            # start (~1-3s) on the first display that opens after an idle
+            # period, paid once, before any game exists to disturb.
             az containerapp update \
               --name couch-kit-relay \
               --resource-group couch-kit-rg \
-              --min-replicas 1 \
-              --max-replicas 1
+              --min-replicas 0 \
+              --max-replicas 1 \
+              --scale-rule-name ws-concurrency \
+              --scale-rule-type http \
+              --scale-rule-http-concurrency 200

--- a/services/relay/src/server.ts
+++ b/services/relay/src/server.ts
@@ -63,6 +63,10 @@ const server = Bun.serve<SocketData, undefined>({
   },
   websocket: {
     maxPayloadLength: 512 * 1024,
+    // Game state broadcasts are JSON and highly repetitive — a card game's
+    // ruleset alone compresses ~84%. The relay forwards opaque envelopes, so
+    // it can compress every payload without understanding any of them.
+    perMessageDeflate: true,
     open(ws) {
       ipCounts.set(ws.data.ip, (ipCounts.get(ws.data.ip) ?? 0) + 1);
       ws.data.conn = { id: ws.data.id, send: (data: string) => ws.send(data) };


### PR DESCRIPTION
Two independent, low-risk wins found while profiling the deployed games. Both measured against a real card-game state broadcast rather than estimated.

## 1. `perMessageDeflate: true`

Game state is repetitive JSON. A crazy-eights `STATE_UPDATE` envelope:

| | Bytes |
|---|---|
| Raw | 9,307 |
| Deflated | **1,492** (84% smaller) |

The relay forwards opaque envelopes, so it compresses every payload without understanding any of them — no game-side changes, no protocol change.

Verified negotiated on the wire, not just configured:

```
Sec-WebSocket-Extensions: permessage-deflate; client_no_context_takeover; server_no_context_takeover
```

(`no_context_takeover` means no cross-message dictionary, which is why the single-message 84% above is the honest number to quote.)

## 2. `--min-replicas 0`

The relay is the only always-on cost in the whole system — one 0.5 vCPU / 1 GiB replica, roughly **$25–40/month**.

Scaling to zero is safe *because* rooms are in-memory and ephemeral. A replica only stops once no WebSocket is open, and an open socket is exactly what a live game is; the HTTP scaler counts held connections as active requests. The cost is a ~1–3s cold start for the first display opened after an idle period — paid before any game exists to disturb.

`--max-replicas` deliberately stays at **1**. A second replica would own a disjoint set of rooms and silently split games in half; that needs the deferred backplane, not a bigger number here.

## Not addressed here

The bigger win is upstream in card-game: ~98% of its broadcast payload is the immutable ruleset, embedded twice in state (`screen.ruleset` + `engineState.ruleset`) and re-sent on every action. Stripping it takes that same envelope from 9,307 bytes to **184**. That changes a game's state shape, so it gets its own PR.

Relay tests pass (17/17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)