### PR TITLE
fix(relay): case-insensitive room codes + Cloudflare CI deploy

### DIFF
--- a/.changeset/soft-pans-shake.md
+++ b/.changeset/soft-pans-shake.md
@@ -1,0 +1,15 @@
+---
+"@couch-kit/client": patch
+---
+
+Room codes are now case-insensitive end to end.
+
+A code created as `6DX8` could not be joined as `6dx8`: the Cloudflare relay
+uppercased the code to route the connection to the right Durable Object, but the
+room registry inside still keyed rooms by the raw string from the
+`CREATE_ROOM` / `JOIN_ROOM` message. The join silently missed and the phone sat
+on "connecting" forever.
+
+Room codes get read off a TV and retyped or re-scanned, so case must not matter.
+They are now canonicalised in one place — the routing core — which fixes both the
+Bun relay and the Worker.

--- a/.github/workflows/deploy-relay-cf.yml
+++ b/.github/workflows/deploy-relay-cf.yml
@@ -1,0 +1,72 @@
+name: Deploy Relay (Cloudflare)
+
+# Deploys the game-agnostic relay (services/relay-worker) to Cloudflare Workers.
+#
+# Unlike the Azure container relay this replaces, a deploy here does not drop
+# live games: rooms are separate Durable Objects, and a new script version rolls
+# out without restarting a shared process.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "services/relay-worker/**"
+      # The Worker bundles the shared routing core from the Bun relay.
+      - "services/relay/src/rooms.ts"
+      - ".github/workflows/deploy-relay-cf.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-relay-cf
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test routing core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # The Worker's behaviour lives almost entirely in this pure core, so its
+      # tests are the meaningful gate before shipping a relay change.
+      - name: Test relay core
+        working-directory: services/relay
+        run: bun test
+
+      - name: Typecheck Worker
+        working-directory: services/relay-worker
+        run: |
+          npm ci
+          npx tsc --noEmit
+
+  deploy:
+    name: Deploy Worker
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Deploy with Wrangler
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: services/relay-worker
+
+      - name: Verify the deployed Worker answers
+        run: |
+          for i in $(seq 1 10); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" \
+              https://couch-kit-relay.faluciano.workers.dev/healthz || true)
+            if [ "$code" = "200" ]; then
+              echo "relay healthy"
+              exit 0
+            fi
+            echo "attempt $i: HTTP $code"
+            sleep 6
+          done
+          echo "relay did not become healthy after deploy"
+          exit 1

--- a/services/relay-worker/README.md
+++ b/services/relay-worker/README.md
@@ -1,0 +1,55 @@
+# Couch Kit relay — Cloudflare Workers + Durable Objects
+
+The game-agnostic relay, with **one Durable Object per room**.
+
+It shares its routing core (`../relay/src/rooms.ts`) with the Bun reference
+server, so both speak an identical wire protocol. This deployment differs only
+in how rooms are hosted:
+
+| | Bun relay (`../relay`) | This Worker |
+| --- | --- | --- |
+| Rooms | all in one process | one Durable Object each |
+| Replicas | exactly 1, forever | not a concept |
+| Deploy | restarts the process, drops live games | rolls out per script version |
+| Idle cost | a container sitting there | none — objects hibernate |
+
+Hibernation is safe here because the relay holds no game state: the browser
+display owns the game. A room object only knows who is in it, and that is
+rebuilt from the sockets themselves on wake (`RelayRooms.restore`).
+
+## Room addressing
+
+Clients connect to `wss://<host>/r/<ROOM>`. The room has to be in the URL
+because a Durable Object must be addressed *before* any frame is read — the
+`CREATE_ROOM` / `JOIN_ROOM` handshake still follows, unchanged, so the Bun relay
+(which ignores the path) accepts the same clients.
+
+Room codes are case-insensitive; `RelayRooms` canonicalises them.
+
+## Local development
+
+No Cloudflare account needed — `wrangler dev` runs the real runtime locally:
+
+```bash
+npm install
+npx wrangler dev --local     # http://localhost:8787
+```
+
+## Deployment
+
+Automatic: pushing to `main` under `services/relay-worker/**` (or the shared
+`rooms.ts`) runs `.github/workflows/deploy-relay-cf.yml`, which tests the core,
+typechecks, deploys, and then health-checks the live URL.
+
+Manual, if you need it:
+
+```bash
+npx wrangler deploy
+```
+
+### Required repository secrets
+
+| Secret | Where to get it |
+| --- | --- |
+| `CLOUDFLARE_API_TOKEN` | Cloudflare dashboard → My Profile → API Tokens → **Edit Cloudflare Workers** template |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare dashboard → Workers & Pages → Account ID |

--- a/services/relay/src/rooms.ts
+++ b/services/relay/src/rooms.ts
@@ -67,6 +67,18 @@ export function byteLength(data: string): number {
   return new TextEncoder().encode(data).length;
 }
 
+/**
+ * Canonical form of a room code.
+ *
+ * Room codes are read off a TV and typed or scanned on a phone, so they are
+ * case-insensitive: `6dx8` and `6DX8` are the same room. Normalizing here — in
+ * the one place that owns room identity — keeps every caller agreeing, whether
+ * the code arrived in a URL or in a `CREATE_ROOM` / `JOIN_ROOM` message.
+ */
+export function normalizeRoomId(roomId: string): string {
+  return roomId.toUpperCase();
+}
+
 /** A single relay connection: an id plus a way to push a raw string to it. */
 export interface RelayConnection {
   id: string;
@@ -128,7 +140,8 @@ export class RelayRooms {
       readonly role: "host" | "player";
     }[],
   ): void {
-    for (const { conn, roomId, role } of entries) {
+    for (const { conn, roomId: raw, role } of entries) {
+      const roomId = normalizeRoomId(raw);
       let room = this.rooms.get(roomId);
       if (!room && role === "host") {
         room = { host: conn, players: new Map() };
@@ -140,7 +153,7 @@ export class RelayRooms {
     // still lands in the room.
     for (const { conn, roomId, role } of entries) {
       if (role !== "player") continue;
-      this.rooms.get(roomId)?.players.set(conn.id, conn);
+      this.rooms.get(normalizeRoomId(roomId))?.players.set(conn.id, conn);
     }
   }
 
@@ -225,11 +238,12 @@ export class RelayRooms {
     }
   }
 
-  private createRoom(conn: RelayConnection, roomId?: string): void {
-    if (!roomId) {
+  private createRoom(conn: RelayConnection, rawRoomId?: string): void {
+    if (!rawRoomId) {
       this.sendError(conn, RelayErrorCodes.MALFORMED, "Missing roomId");
       return;
     }
+    const roomId = normalizeRoomId(rawRoomId);
     if (this.rooms.has(roomId)) {
       this.sendError(conn, RelayErrorCodes.ROOM_EXISTS, "Room already exists");
       return;
@@ -247,11 +261,12 @@ export class RelayRooms {
     });
   }
 
-  private joinRoom(conn: RelayConnection, roomId?: string): void {
-    if (!roomId) {
+  private joinRoom(conn: RelayConnection, rawRoomId?: string): void {
+    if (!rawRoomId) {
       this.sendError(conn, RelayErrorCodes.MALFORMED, "Missing roomId");
       return;
     }
+    const roomId = normalizeRoomId(rawRoomId);
     const room = this.rooms.get(roomId);
     if (!room) {
       this.sendError(conn, RelayErrorCodes.ROOM_NOT_FOUND, "Room not found");

--- a/services/relay/tests/rooms.test.ts
+++ b/services/relay/tests/rooms.test.ts
@@ -304,3 +304,58 @@ describe("RelayRooms", () => {
     expect(rooms.handleMessage(c, noop)).toBe(true);
   });
 });
+
+describe("room code case", () => {
+  test("a room created upper-case is joinable lower-case", () => {
+    // Codes are read off a TV and retyped or re-scanned on a phone; some
+    // scanners and keyboards change the case. The room must be the same room.
+    const rooms = new RelayRooms();
+    const host = conn("h");
+    const player = conn("p");
+
+    rooms.handleMessage(host, JSON.stringify({ type: "CREATE_ROOM", roomId: "6DX8" }));
+    rooms.handleMessage(player, JSON.stringify({ type: "JOIN_ROOM", roomId: "6dx8" }));
+
+    expect(player.sent[0].type).toBe(RelayMessageTypes.ROOM_JOINED);
+    expect(host.sent[1]).toMatchObject({ type: RelayMessageTypes.PEER_JOINED, peerId: "p" });
+  });
+
+  test("a room created lower-case is joinable upper-case", () => {
+    const rooms = new RelayRooms();
+    const host = conn("h");
+    const player = conn("p");
+
+    rooms.handleMessage(host, JSON.stringify({ type: "CREATE_ROOM", roomId: "abcd" }));
+    rooms.handleMessage(player, JSON.stringify({ type: "JOIN_ROOM", roomId: "ABCD" }));
+
+    expect(player.sent[0].type).toBe(RelayMessageTypes.ROOM_JOINED);
+  });
+
+  test("codes differing only by case are the same room, not two", () => {
+    const rooms = new RelayRooms();
+    const first = conn("h1");
+    const second = conn("h2");
+
+    rooms.handleMessage(first, JSON.stringify({ type: "CREATE_ROOM", roomId: "ABCD" }));
+    rooms.handleMessage(second, JSON.stringify({ type: "CREATE_ROOM", roomId: "abcd" }));
+
+    expect(second.sent[0].code).toBe(RelayErrorCodes.ROOM_EXISTS);
+    expect(rooms.roomCount).toBe(1);
+  });
+
+  test("membership and routing use the canonical code", () => {
+    const rooms = new RelayRooms();
+    const host = conn("h");
+    const player = conn("p");
+    rooms.handleMessage(host, JSON.stringify({ type: "CREATE_ROOM", roomId: "xy12" }));
+    rooms.handleMessage(player, JSON.stringify({ type: "JOIN_ROOM", roomId: "XY12" }));
+
+    expect(rooms.membershipOf("h")).toEqual({ roomId: "XY12", role: "host" });
+    expect(rooms.membershipOf("p")).toEqual({ roomId: "XY12", role: "player" });
+
+    host.sent.length = 0;
+    player.sent.length = 0;
+    rooms.handleMessage(host, JSON.stringify({ type: "DATA", data: "s" }));
+    expect(player.sent[0]).toMatchObject({ type: RelayMessageTypes.DATA, data: "s" });
+  });
+});


### PR DESCRIPTION
Two things a real phone found that same-machine testing didn't.

## 1. Room codes were case-sensitive (the "stuck on connecting" bug)

Reproduced on production: display created room `6DX8`, controller opened with `?room=6dx8` → **stuck on "connecting" forever**, display still showing 0 players.

The Worker uppercases the code to route the connection to the right Durable Object, but `RelayRooms` inside keyed the room by the raw string from the `CREATE_ROOM` / `JOIN_ROOM` message. Two sources of truth for room identity, so the join silently missed — and because the failure surfaced as `ROOM_NOT_FOUND` with no client-side handling, the phone just sat there.

My own comment in the Worker claimed codes were "case-insensitive for people typing them off a TV". That was only ever true of routing.

**Fix:** canonicalise in the routing core, which is the one place that owns room identity. Both the Bun relay and the Worker inherit it. Four new tests cover create-upper/join-lower, create-lower/join-upper, codes differing only by case being one room rather than two, and membership/routing using the canonical code.

Verified on production after redeploying the Worker: `?room=l8e8` now joins room `L8E8` and the display shows the player.

## 2. Worker deploys are now automated

The Worker was deployed by a hand-assembled multipart API upload — fine once, not something to repeat.

`deploy-relay-cf.yml` runs on pushes touching `services/relay-worker/**` or the shared `rooms.ts`: test the routing core → typecheck → `wrangler deploy` → health-check the live URL before calling it done.

Worth noting the contrast with the Azure workflow this replaces: **deploying no longer drops live games.** Rooms are separate Durable Objects, so a new script version rolls out without restarting a shared process.

### Needs two repository secrets

| Secret | Where |
| --- | --- |
| `CLOUDFLARE_API_TOKEN` | My Profile → API Tokens → **Edit Cloudflare Workers** template |
| `CLOUDFLARE_ACCOUNT_ID` | Workers & Pages → Account ID |

I deliberately did not create the token myself — it would have had to pass through this transcript to reach the secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)