### PR TITLE
fix(devtools): over-strict peer dep, and the runaway majors it caused

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/.changeset/olive-pears-shout.md
+++ b/.changeset/olive-pears-shout.md
@@ -1,0 +1,18 @@
+---
+"@couch-kit/devtools": patch
+---
+
+Fix an over-strict peer dependency that pinned devtools to one exact client
+release.
+
+The peer range was `workspace:*`, which publishing rewrites to the current
+version — so `@couch-kit/devtools@3.0.0` demanded *exactly*
+`@couch-kit/client@0.11.0`, and any client patch would conflict. devtools uses
+one type-only import from client and nothing at runtime, so the peer is now a
+wide, optional range (`>=0.9.0 <1.0.0`).
+
+This also stops the runaway majors: because a peerDependency range change is
+treated as breaking, every client release majored devtools — 0.2.10 → 1.0.0 →
+2.0.0 → 3.0.0 in a day, each changelog reading "Patch Changes". Changesets is
+now configured to bump peer dependents only when a release actually leaves
+their range.

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/client": {
       "name": "@couch-kit/client",
-      "version": "0.9.0",
+      "version": "0.11.0",
       "dependencies": {
         "@couch-kit/core": "workspace:*",
       },
@@ -50,7 +50,7 @@
     },
     "packages/devtools": {
       "name": "@couch-kit/devtools",
-      "version": "1.0.0",
+      "version": "3.0.0",
       "devDependencies": {
         "@couch-kit/client": "workspace:*",
         "@couch-kit/core": "workspace:*",
@@ -64,13 +64,16 @@
         "typescript": "^7.0.0",
       },
       "peerDependencies": {
-        "@couch-kit/client": "workspace:*",
+        "@couch-kit/client": ">=0.9.0 <1.0.0",
         "react": ">=18.0.0",
       },
+      "optionalPeers": [
+        "@couch-kit/client",
+      ],
     },
     "packages/display": {
       "name": "@couch-kit/display",
-      "version": "0.1.2",
+      "version": "0.2.2",
       "dependencies": {
         "@couch-kit/client": "workspace:*",
         "@couch-kit/core": "workspace:*",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -39,7 +39,7 @@
     "typescript": "^7.0.0"
   },
   "peerDependencies": {
-    "@couch-kit/client": "workspace:*",
+    "@couch-kit/client": ">=0.9.0 <1.0.0",
     "react": ">=18.0.0"
   },
   "publishConfig": {
@@ -54,5 +54,10 @@
     "type": "git",
     "url": "https://github.com/faluciano/react-native-couch-kit.git",
     "directory": "packages/devtools"
+  },
+  "peerDependenciesMeta": {
+    "@couch-kit/client": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
You were right that the devtools majors shouldn't be happening. There were two problems, and the second is worse than the version noise.

## 1. The published peer range was an exact pin

```
$ npm view @couch-kit/devtools@3.0.0 peerDependencies
{ '@couch-kit/client': '0.11.0', react: '>=18.0.0' }
```

The source declares `"@couch-kit/client": "workspace:*"`, and publishing rewrites that to the current version. So devtools@3.0.0 demands **exactly** client 0.11.0 — a client patch release would produce a peer conflict for anyone who has both.

devtools uses **one type-only import** from client (`import type { DebugPanelData }`) and nothing at runtime, so a hard exact peer was never right. Now a wide, optional range: `>=0.9.0 <1.0.0`.

## 2. That declaration is what forced the majors

Changesets treats any peerDependency range change as breaking, so *every* client release majored devtools:

| devtools | trigger | changelog said |
| --- | --- | --- |
| 1.0.0 | client 0.9.0 | "Patch Changes" |
| 2.0.0 | client 0.10.0 | "Patch Changes" |
| 3.0.0 | client 0.11.0 | "Patch Changes" |

Three majors in a day for dependency bumps. Major numbers that don't mean anything are worse than useless — they train people to ignore them.

Changesets is now configured with `onlyUpdatePeerDependentsWhenOutOfRange`, so peer dependents bump only when a release actually leaves their declared range.

## Verified

`changeset status` on this branch reports **devtools at patch, nothing at major** — the same situation that previously produced a major. devtools tests (20) pass, typecheck clean.

Only devtools had this; I audited the peer declarations across all seven packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)