### PR TITLE
docs: bring the docs in line with what shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Turn an Android TV / Fire TV into a local party-game console and use phones as w
 
 - **Local-first:** TV runs HTTP (controller) + WebSocket (game) on your LAN.
 - **TV-as-server:** Single source of truth lives on the TV.
+- **Or play cross-network:** a browser display owns the game and phones join by
+  room code through a small, game-agnostic relay — same reducer, no LAN needed.
 - **Shared reducer:** One reducer shared between host + controller.
 - **Time sync + preloading:** Helpers for timing-sensitive games and heavy assets.
 - **Session recovery:** Players automatically get their state back after refreshing or reconnecting.
@@ -69,14 +71,33 @@ sequenceDiagram
 
 ## Prerequisites / Supported
 
-- **Devices:** Android TV / Fire TV (host). Phones run any modern mobile browser (client).
-- **Network:** TV + phones on the same LAN/Wi-Fi. This is not an internet relay.
-- **Ports:** `8080` (HTTP) and `8082` (WebSocket) reachable on the LAN (configurable).
+- **Devices:** Android TV / Fire TV (host), or any browser as the display. Phones run any modern mobile browser (client).
+- **Network:** LAN mode needs TV + phones on the same Wi-Fi. Relay mode does not — see [Two ways to play](#two-ways-to-play).
+- **Ports:** LAN mode uses `8080` (HTTP) and `8082` (WebSocket) on the LAN (configurable).
 - **Native deps:** `@couch-kit/host` requires Expo modules and React Native native modules; it is not a pure-JS package.
+
+## Two ways to play
+
+Both run the **same reducer**; only who hosts the runtime and how phones reach it differ.
+
+| | LAN (default) | Relay (cross-network) |
+| --- | --- | --- |
+| Display | Android TV app (`@couch-kit/host`) | Any browser (`@couch-kit/display`) |
+| Runtime owner | the TV | the browser display |
+| Phones reach it via | direct WebSocket on the LAN | room code through a relay |
+| Same Wi-Fi required | yes | no |
+| Extra infrastructure | none | one relay deployment, shared by every game |
+
+Relay mode is opt-in: pass `createRelayTransport({ url, roomId })` to `useGameClient`
+and run the display with `RelayDisplayHost`. The relay `url` is **required config
+with no default** — the SDK never routes your players through someone else's
+server. Two implementations ship in `services/`: a Cloudflare Worker
+(`relay-worker`, one Durable Object per room) and a single-process Bun server
+(`relay`) for self-hosting.
 
 ## Non-goals
 
-- Internet matchmaking / relay servers
+- Matchmaking or lobby discovery — relay rooms are reached by a code you share, not browsed
 - Anti-cheat, account systems, payments
 - Hard security guarantees on untrusted networks
 
@@ -383,8 +404,16 @@ When you make changes to the library:
 | **`@couch-kit/runtime`**  | Owns authoritative game state, sessions, authorization, and transport-neutral protocol processing. |
 | **`@couch-kit/host`**     | React Native adapter that provides the LAN WebSocket/static servers and renders the TV display.    |
 | **`@couch-kit/client`**   | Runs on the phone browser. Connects to the host and renders the controller UI.                     |
+| **`@couch-kit/display`**  | Browser display that owns the runtime and reaches phones through the relay (`RelayDisplayHost`).   |
 | **`@couch-kit/cli`**      | CLI tools to scaffold, bundle, and simulate web controllers.                                       |
 | **`@couch-kit/devtools`** | Optional debug overlay component for web controllers.                                              |
+
+Not published, but part of the repo:
+
+| Service | Purpose |
+| --- | --- |
+| **`services/relay-worker`** | The relay on Cloudflare Workers — one Durable Object per room. What Couch Kit runs. |
+| **`services/relay`** | The same relay as a single-process Bun server: reference implementation and self-host option. |
 
 ## 🔄 Release Flow
 

--- a/scripts/generate-llms-txt.ts
+++ b/scripts/generate-llms-txt.ts
@@ -646,6 +646,7 @@ function useGameClient<S extends IGameState, A extends IAction>(
   status: "connecting" | "connected" | "disconnected" | "error";
   state: S;
   playerId: string | null;
+  disconnectReason: string | null;  // relay error code (ROOM_NOT_FOUND, ...) on terminal failures
   sendAction: (action: A) => void;
   getServerTime: () => number;
   rtt: number;
@@ -663,6 +664,51 @@ function useGameClient<S extends IGameState, A extends IAction>(
 5. \`sendAction()\` applies optimistic local update then sends to host
 6. On close, automatically reconnects with exponential backoff (up to \`maxRetries\`)
 7. \`disconnect()\` prevents auto-reconnect; \`reconnect()\` resets attempts and reconnects
+
+### Cross-network play (relay)
+
+By default the controller talks to the TV over the LAN. To let phones join a
+**browser display** from any network, pass a relay transport instead. The relay
+is game-agnostic and routes opaque envelopes by room code; the \`url\` is
+required and has no default.
+
+\`\`\`typescript
+import {
+  useGameClient,
+  createRelayTransport,
+  useRelayRoom,
+  describeRelayError,
+} from "@couch-kit/client";
+
+function App() {
+  const { roomId, setRoomId } = useRelayRoom();  // reads ?room=CODE, syncs the URL
+
+  // Only mount the client once a room exists: with no relay transport it falls
+  // back to the LAN socket and retries a host that a hosted controller cannot have.
+  if (!roomId) return <JoinScreen onJoin={setRoomId} />;
+  return <Controller roomId={roomId} onRejoin={setRoomId} />;
+}
+
+function Controller({ roomId, onRejoin }) {
+  const { state, sendAction, disconnectReason } = useGameClient({
+    reducer, initialState,
+    createTransport: createRelayTransport({ url: RELAY_URL, roomId }),
+  });
+
+  // Terminal room failures are worth explaining; ordinary drops are retried.
+  const joinError = describeRelayError(disconnectReason);
+  if (joinError) return <JoinScreen onJoin={onRejoin} error={joinError} />;
+  // ...
+}
+\`\`\`
+
+- \`useRelayRoom()\` → \`{ roomId, setRoomId, clearRoomId }\`, seeded from \`?room=CODE\` and written back to the URL so reloads and shared links keep it.
+- \`normalizeRoomCode(input)\` canonicalises what people type (\`"ab 12"\`, \`"AB-12"\` → \`"AB12"\`); room codes are case-insensitive end to end.
+- \`describeRelayError(reason)\` turns a relay error code into player-facing text, or \`null\` for an ordinary drop.
+- \`relayRoomUrl(url, roomId)\` builds the socket URL (\`<url>/r/<ROOM>\`); the transports call it for you.
+
+The display side is \`@couch-kit/display\`'s \`RelayDisplayHost\`, which owns the
+authoritative runtime in the browser and speaks the same reducer.
 
 ### calculateTimeSync
 

--- a/services/relay/README.md
+++ b/services/relay/README.md
@@ -36,8 +36,8 @@ matching the single-instance model). Defaults are generous for party-game scale:
 | Message size                   | 256 KiB | _(code: `MAX_MESSAGE_BYTES`)_ | `MESSAGE_TOO_LARGE` error             |
 
 Set `ALLOWED_ORIGINS` (comma-separated) to reject WebSocket upgrades from other
-origins with `403`; unset (the default) allows any origin, since displays run on
-varying Vercel URLs. The rate/room/player limits are constructor options on
+origins with `403`; unset (the default) allows any origin, since displays are
+hosted at whatever URL each game happens to use. The rate/room/player limits are constructor options on
 `RelayRooms` (see `DEFAULT_LIMITS`); the connection-per-IP cap and origin
 allowlist are read from env in `server.ts`.
 
@@ -48,7 +48,14 @@ codes and auth tokens remain future work.
 
 ## Protocol (summary)
 
-Clients speak JSON. `data` is an opaque Couch Kit message string.
+Clients connect to **`wss://<host>/r/<ROOM>`** and then speak JSON; `data` is an
+opaque Couch Kit message string. The room appears in both the URL and the
+handshake because a per-room relay (the Durable Object one) has to route the
+socket before reading any frame — this server ignores the path, so both work.
+
+**Room codes are case-insensitive.** They get read off a TV and retyped or
+re-scanned, so `ab12` and `AB12` are the same room; `RelayRooms` canonicalises
+them in one place.
 
 | From    | Message                                   | Effect                                  |
 | ------- | ----------------------------------------- | --------------------------------------- |


### PR DESCRIPTION
Doc audit after the relay + hosting migration. The most striking gap: the README still told people the opposite of what the repo does.

## README said relays were a non-goal

> **Network:** TV + phones on the same LAN/Wi-Fi. This is not an internet relay.

> ## Non-goals
> - Internet matchmaking / relay servers

Meanwhile the repo ships `@couch-kit/display`, two relay implementations, and a deployed relay serving three games. `@couch-kit/display` was also missing from the architecture table entirely.

Changes:

- **"Two ways to play"** — a comparison of LAN vs relay: who owns the runtime, how phones reach it, whether same-Wi-Fi is required, what infrastructure each needs.
- Architecture table gains `@couch-kit/display`, plus a second table for the two `services/` relays (Cloudflare Worker and Bun).
- The non-goal is narrowed to **matchmaking and lobby discovery**, which really are out of scope — relay rooms are reached by a code you share, not browsed.

## services/relay

Documents `/r/<ROOM>` addressing (and *why*: a per-room relay must route before reading a frame) and that room codes are case-insensitive. Drops a stale mention of Vercel.

## llms.txt

The generator listed the display package but documented nothing about relay play. Adds `disconnectReason` to the `useGameClient` return type and a **cross-network section** covering `useRelayRoom`, `describeRelayError`, `normalizeRoomCode`, and `relayRoomUrl` — including the caveat that cost real debugging time: **only mount the client once a room exists**, or it falls back to a LAN socket a hosted controller cannot have. Regenerated.

Game repo READMEs are updated in their own PRs (buzz, card-game, domino).

🤖 Generated with [Claude Code](https://claude.com/claude-code)