### PR TITLE
feat(relay-worker): origin allowlist and per-IP connection limit

### DIFF
--- a/services/relay-worker/src/index.ts
+++ b/services/relay-worker/src/index.ts
@@ -12,10 +12,17 @@
 
 export { RelayRoom } from "./room";
 
+/** Cloudflare's rate-limiting binding (see `unsafe.bindings` in wrangler.jsonc). */
+interface RateLimiter {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
 export interface Env {
   ROOMS: DurableObjectNamespace;
   /** Optional comma-separated origin allowlist. Empty/unset = open. */
   ALLOWED_ORIGINS?: string;
+  /** Caps new connections per IP. Absent in local dev. */
+  CONNECT_LIMITER?: RateLimiter;
 }
 
 /**
@@ -62,6 +69,18 @@ export default {
     const code = roomCodeFrom(url);
     if (code === null) {
       return new Response("Missing or invalid room code", { status: 400 });
+    }
+
+    // Cap how fast one address can open rooms/connections. This is the
+    // replacement for the Bun relay's per-IP connection cap; Cloudflare's own
+    // DDoS protection sits in front of it. Absent locally, where the binding
+    // does not exist.
+    const ip = request.headers.get("CF-Connecting-IP");
+    if (env.CONNECT_LIMITER && ip) {
+      const { success } = await env.CONNECT_LIMITER.limit({ key: ip });
+      if (!success) {
+        return new Response("Too many connections", { status: 429 });
+      }
     }
 
     // idFromName maps a room code to a stable object. The object exists

--- a/services/relay-worker/wrangler.jsonc
+++ b/services/relay-worker/wrangler.jsonc
@@ -13,5 +13,24 @@
       "tag": "v1",
       "new_sqlite_classes": ["RelayRoom"]
     }
-  ]
+  ],
+  "vars": {
+    // Hygiene, not a security boundary: `Origin` stops a random web page from
+    // opening sockets to this relay, but any non-browser client can forge it.
+    // Local dev ports are included so testing against the deployed relay works.
+    "ALLOWED_ORIGINS": "https://buzz-display.pages.dev,https://buzz-controller.pages.dev,https://card-game-display.pages.dev,https://card-game-controller.pages.dev,https://domino-display.pages.dev,https://domino-controller.pages.dev,http://localhost:5173,http://localhost:5174"
+  },
+  "unsafe": {
+    "bindings": [
+      {
+        // Replaces the per-IP connection cap the Bun relay had
+        // (MAX_CONNECTIONS_PER_IP), which was lost in the port to Workers.
+        // Caps new connections per IP; established sockets are unaffected.
+        "name": "CONNECT_LIMITER",
+        "type": "ratelimit",
+        "namespace_id": "1001",
+        "simple": { "limit": 60, "period": 60 }
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Two of the three items from the security review. Both are gaps the port to Workers introduced.

## `ALLOWED_ORIGINS` was never actually set

The code supported it; the deployed Worker had only the `ROOMS` binding, so any web page could open sockets to the relay. Now set in `wrangler.jsonc` — the six Pages origins plus local dev ports — so it **survives redeploys** rather than living in dashboard state that a `wrangler deploy` would drop.

Stated plainly in the config comment: this is hygiene, not a security boundary. `Origin` is trivially forged by any non-browser client. It stops casual embedding from random sites and nothing more.

## The per-IP cap came back

The Bun relay enforced `MAX_CONNECTIONS_PER_IP=50`. That control vanished in the port and I didn't flag it at the time. Restored in spirit with Cloudflare's rate-limiting binding — 60 new connections per IP per minute — sitting behind Cloudflare's own DDoS protection.

Connection *rate* rather than concurrent count, which suits the actual threat here (room-code enumeration needs a fresh connection per guess, since the room is in the URL).

The binding doesn't exist in local dev, so the code treats it as optional rather than crashing `wrangler dev`.

## Verified

Against a local `wrangler dev`:

| | |
| --- | --- |
| `Origin: https://buzz-display.pages.dev` | **101** upgrade |
| `Origin: https://evil.example.com` | **403** refused |

All 13 protocol behaviours still pass (the test client now sends an allowed origin, which is itself proof the allowlist is live).

## Not included

Server-minted room codes — the third item. It needs a design pass, not a patch: with Durable Objects the room is in the URL, so a display cannot connect *and then* be told its code. The likely shape is a `POST /rooms` that mints an unguessable code before the socket opens, which is a protocol addition rather than a config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)