### PR TITLE
feat(relay): let the relay assign room codes

### DIFF
--- a/.changeset/large-donkeys-shout.md
+++ b/.changeset/large-donkeys-shout.md
@@ -1,0 +1,29 @@
+---
+"@couch-kit/display": minor
+"@couch-kit/client": minor
+---
+
+Let the relay assign room codes
+
+`RelayDisplayHost`'s `roomId` is now optional. Omit it and the relay mints an
+unused six-character code, reported through the new `onRoomCode` callback and
+the `roomCode` getter.
+
+A display could never check its own code for collisions — only the relay knows
+which codes are live — so a self-chosen code could land on a game already in
+progress, and did so only after it was on screen. Minted codes are drawn from
+the CSPRNG over a 32-character alphabet without `O`/`0` or `I`/`1`, giving about
+1.07 billion codes.
+
+Existing callers that pass `roomId` keep their current behaviour, including
+`ROOM_EXISTS` when the code is taken. New callers should expect the code to
+arrive one round trip after connecting rather than being known up front:
+
+```ts
+const [roomCode, setRoomCode] = useState<string | null>(null);
+new RelayDisplayHost({ url, onRoomCode: setRoomCode, reducer, initialState });
+```
+
+Relays need a matching update to mint: both bundled implementations
+(`services/relay`, `services/relay-worker`) support it. A display that omits
+`roomId` against an older relay gets `MALFORMED`.

--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ sequenceDiagram
   participant R as 🔀 Relay
   participant D as 🖥️ Display
 
-  D->>R: CREATE_ROOM { roomId }
-  R-->>D: ROOM_CREATED
+  D->>R: CREATE_ROOM
+  Note over R: mints an unused code
+  R-->>D: ROOM_CREATED { roomId }
 
   P->>R: JOIN_ROOM { roomId }
   R-->>P: ROOM_JOINED
@@ -143,6 +144,35 @@ with no default** — the SDK never routes your players through someone else's
 server. Two implementations ship in `services/`: a Cloudflare Worker
 (`relay-worker`, one Durable Object per room) and a single-process Bun server
 (`relay`) for self-hosting.
+
+### Room codes
+
+The relay assigns the code; a display does not invent one. Only the relay can
+tell whether a code is already in use, so a self-chosen code can collide with a
+live game — and it is already on screen by the time anyone finds out.
+
+```ts
+new RelayDisplayHost({
+  url: RELAY_URL,
+  onRoomCode: setRoomCode, // arrives one round trip after connecting
+  reducer,
+  initialState,
+});
+```
+
+Codes are six characters from a 32-character alphabet that omits `O`/`0` and
+`I`/`1`, drawn from the CSPRNG: about 1.07 billion of them, so guessing your way
+into a live game is impractical. Pass `roomId` to keep a fixed code anyway — the
+relay will reject it with `ROOM_EXISTS` if it is taken.
+
+How a code gets reserved differs by relay, and only inside the relay:
+
+- **Bun** holds every room in one table and checks candidates against it.
+- **Workers** has no such table by design. The router offers a candidate to the
+  Durable Object that *would* own it; being single-threaded, that object can
+  answer "already hosting" atomically, and the router retries on a collision.
+  Reservation rides along with the WebSocket upgrade, so there is no extra round
+  trip, and a code frees itself when its object empties.
 
 ## Non-goals
 
@@ -424,7 +454,7 @@ yalc add @couch-kit/core @couch-kit/runtime @couch-kit/client @couch-kit/host
 bun install
 ```
 
-> **Note:** We do not use the `--link` flag. Keeping the default `file:` protocol ensures files are copied _inside_ your project root, which allows Metro Bundler to watch them correctly without extra configuration.
+> **Note:** We do not use the `--link` flag. Keeping the default `file:` protocol ensures files are copied *inside* your project root, which allows Metro Bundler to watch them correctly without extra configuration.
 
 **Iterating:**
 

--- a/packages/client/src/relay-protocol.ts
+++ b/packages/client/src/relay-protocol.ts
@@ -144,12 +144,27 @@ export type RelayMessage = RelayClientMessage | RelayServerMessage;
  * that keep every room in one process (the Bun reference server) ignore the
  * path, so this is safe to send to either.
  *
+ * Passing no room code addresses {@link RELAY_MINT_PATH} instead, asking the
+ * relay to allocate one; the code comes back in `ROOM_CREATED`.
+ *
  * @param url - Base relay URL, e.g. `wss://relay.example.com`.
- * @param roomId - Room code to address.
+ * @param roomId - Room code to address, or omitted to have one minted.
  */
-export function relayRoomUrl(url: string, roomId: string): string {
+export function relayRoomUrl(url: string, roomId?: string): string {
   const trimmed = url.replace(/\/+$/, "");
   const [base, query] = trimmed.split("?", 2);
-  const path = `${base}/r/${encodeURIComponent(roomId)}`;
+  const path =
+    roomId === undefined
+      ? `${base}${RELAY_MINT_PATH}`
+      : `${base}/r/${encodeURIComponent(roomId)}`;
   return query ? `${path}?${query}` : path;
 }
+
+/**
+ * Path that asks the relay to allocate a room code.
+ *
+ * Reserved, so it can never be mistaken for a room code. Single-process relays
+ * ignore the path and mint from the `CREATE_ROOM` message alone; sharded relays
+ * need it, because they must choose the shard before any frame arrives.
+ */
+export const RELAY_MINT_PATH = "/new";

--- a/packages/display/src/relay-display-host.ts
+++ b/packages/display/src/relay-display-host.ts
@@ -23,8 +23,23 @@ export interface RelayDisplayHostOptions<S extends IGameState, A extends IAction
   extends GameHostRuntimeConfig<S, A> {
   /** WebSocket URL of the shared relay server. */
   url: string;
-  /** Room code phones will use to reach this display. */
-  roomId: string;
+  /**
+   * Room code phones will use to reach this display.
+   *
+   * Omit it — the normal case — and the relay allocates one, reporting it via
+   * {@link RelayDisplayHostOptions.onRoomCode} and {@link RelayDisplayHost.roomCode}.
+   * Only the relay can tell whether a code is already in use, so a code chosen
+   * here may be rejected as `ROOM_EXISTS`; supply one only when something
+   * outside the relay already fixed it.
+   */
+  roomId?: string;
+  /**
+   * Called once the room exists and its code is known.
+   *
+   * A minted code is not available synchronously, so a display renders a
+   * placeholder until this fires — roughly a round trip to the relay.
+   */
+  onRoomCode?: (roomCode: string) => void;
 }
 
 /**
@@ -47,21 +62,27 @@ export interface RelayDisplayHostOptions<S extends IGameState, A extends IAction
 export class RelayDisplayHost<S extends IGameState, A extends IAction> {
   private readonly runtime: GameHostRuntime<S, A>;
   private readonly ws: WebSocket;
-  private readonly roomId: string;
+  /** Null until the relay confirms the room, when the code is relay-assigned. */
+  private assignedRoomId: string | null;
+  private readonly onRoomCode?: (roomCode: string) => void;
   /** Connected phone connection ids (relay peer ids). */
   private readonly peers = new Set<string>();
 
   constructor(options: RelayDisplayHostOptions<S, A>) {
-    const { url, roomId, ...runtimeConfig } = options;
-    this.roomId = roomId;
+    const { url, roomId, onRoomCode, ...runtimeConfig } = options;
+    this.assignedRoomId = roomId ?? null;
+    this.onRoomCode = onRoomCode;
     this.runtime = new GameHostRuntime<S, A>(runtimeConfig);
     this.ws = new WebSocket(relayRoomUrl(url, roomId));
 
     this.ws.onopen = () => {
+      // No roomId asks the relay to allocate one. Sending the field as
+      // undefined omits it from the JSON, which is what the relay reads as
+      // "you pick".
       this.ws.send(
         JSON.stringify({
           type: RelayMessageTypes.CREATE_ROOM,
-          roomId: this.roomId,
+          roomId: this.assignedRoomId ?? undefined,
         }),
       );
     };
@@ -89,6 +110,15 @@ export class RelayDisplayHost<S extends IGameState, A extends IAction> {
     this.runtime.setTransport(transport);
   }
 
+  /**
+   * The room code phones join with, or `null` before the relay has assigned
+   * one. See {@link RelayDisplayHostOptions.onRoomCode} to be told when it
+   * arrives.
+   */
+  get roomCode(): string | null {
+    return this.assignedRoomId;
+  }
+
   /** Current authoritative game state. */
   getState = (): S => this.runtime.getState();
 
@@ -109,7 +139,10 @@ export class RelayDisplayHost<S extends IGameState, A extends IAction> {
   private sendEnvelope(message: HostMessage, to?: string): void {
     const envelope: Record<string, unknown> = {
       type: RelayMessageTypes.DATA,
-      roomId: this.roomId,
+      // The relay routes by the sender's membership, not this field, so it is
+      // only ever informational — and nothing is sent before a peer joins,
+      // which cannot happen until the room exists.
+      roomId: this.assignedRoomId ?? undefined,
       data: JSON.stringify(message),
     };
     if (to !== undefined) envelope.to = to;
@@ -147,10 +180,16 @@ export class RelayDisplayHost<S extends IGameState, A extends IAction> {
           );
         break;
       }
+      case RelayMessageTypes.ROOM_CREATED:
+        // Carries the code when the relay chose it, and confirms the code when
+        // the caller supplied one.
+        this.assignedRoomId = msg.roomId;
+        this.onRoomCode?.(msg.roomId);
+        break;
       case RelayMessageTypes.ERROR:
         this.runtime.handleError(new Error(msg.message));
         break;
-      // ROOM_CREATED / ROOM_JOINED are acknowledgements; no action needed.
+      // ROOM_JOINED is an acknowledgement; no action needed.
     }
   }
 }

--- a/packages/display/tests/relay-display-host.test.ts
+++ b/packages/display/tests/relay-display-host.test.ts
@@ -217,3 +217,111 @@ describe("RelayDisplayHost", () => {
     expect(ws.closed).toBe(true);
   });
 });
+
+describe("relay-assigned room codes", () => {
+  /** A host that lets the relay pick the code. */
+  function makeMintingHost() {
+    const codes: string[] = [];
+    const host = new RelayDisplayHost<TestState, TestAction>({
+      url: "wss://relay.test",
+      onRoomCode: (code) => codes.push(code),
+      reducer,
+      initialState,
+      stateThrottleMs: 1,
+    });
+    return { host, ws: MockWebSocket.last!, codes };
+  }
+
+  test("addresses the mint path when no code is supplied", () => {
+    const { ws } = makeMintingHost();
+    // A sharded relay picks the object before reading any frame, so "give me a
+    // room" has to be visible in the URL and cannot look like a room code.
+    expect(ws.url).toBe("wss://relay.test/new");
+  });
+
+  test("asks the relay to choose, rather than naming a code", () => {
+    const { ws } = makeMintingHost();
+    ws.open();
+    // An absent roomId is what the relay reads as "you pick"; sending null or
+    // an empty string would be rejected as malformed.
+    expect(ws.frames()).toEqual([{ type: RelayMessageTypes.CREATE_ROOM }]);
+  });
+
+  test("reports the code once the relay assigns it", () => {
+    const { host, ws, codes } = makeMintingHost();
+    ws.open();
+    expect(host.roomCode).toBeNull();
+
+    ws.fromServer({
+      type: RelayMessageTypes.ROOM_CREATED,
+      roomId: "K7M2QX",
+      peerId: "h",
+    });
+
+    expect(codes).toEqual(["K7M2QX"]);
+    expect(host.roomCode).toBe("K7M2QX");
+  });
+
+  test("still addresses a caller-supplied code directly", () => {
+    const { host, ws } = makeHost();
+    expect(ws.url).toBe("wss://relay.test/r/ROOM");
+    expect(host.roomCode).toBe("ROOM");
+  });
+
+  test("confirms a caller-supplied code when the relay acknowledges it", () => {
+    const seen: string[] = [];
+    const host = new RelayDisplayHost<TestState, TestAction>({
+      url: "wss://relay.test",
+      roomId: "ROOM",
+      onRoomCode: (code) => seen.push(code),
+      reducer,
+      initialState,
+      stateThrottleMs: 1,
+    });
+    const ws = MockWebSocket.last!;
+    ws.open();
+    ws.fromServer({
+      type: RelayMessageTypes.ROOM_CREATED,
+      roomId: "ROOM",
+      peerId: "h",
+    });
+
+    expect(seen).toEqual(["ROOM"]);
+    expect(host.roomCode).toBe("ROOM");
+  });
+
+  test("routes game traffic under the assigned code", async () => {
+    const { ws } = makeMintingHost();
+    ws.open();
+    ws.fromServer({
+      type: RelayMessageTypes.ROOM_CREATED,
+      roomId: "K7M2QX",
+      peerId: "h",
+    });
+    ws.sent.length = 0;
+
+    // Nothing is sent before the room exists, so every envelope carries the
+    // minted code rather than the placeholder it started with.
+    ws.fromServer({
+      type: RelayMessageTypes.PEER_JOINED,
+      roomId: "K7M2QX",
+      peerId: "p1",
+    });
+    ws.fromServer({
+      type: RelayMessageTypes.DATA,
+      roomId: "K7M2QX",
+      from: "p1",
+      data: JSON.stringify({
+        type: "JOIN",
+        payload: { secret: SECRET, name: "P1" },
+      }),
+    });
+    await flush();
+
+    const envelopes = ws.frames().filter((f) => f.type === RelayMessageTypes.DATA);
+    expect(envelopes.length).toBeGreaterThan(0);
+    for (const envelope of envelopes) {
+      expect(envelope.roomId).toBe("K7M2QX");
+    }
+  });
+});

--- a/services/relay-worker/src/index.ts
+++ b/services/relay-worker/src/index.ts
@@ -10,6 +10,9 @@
  * two rooms to interfere with each other.
  */
 
+import { generateRoomCode } from "../../relay/src/rooms";
+import { ASSIGNED_CODE_HEADER } from "./room";
+
 export { RelayRoom } from "./room";
 
 /** Cloudflare's rate-limiting binding (see `unsafe.bindings` in wrangler.jsonc). */
@@ -42,12 +45,54 @@ function originAllowed(request: Request, env: Env): boolean {
   return origin !== null && allowed.includes(origin);
 }
 
+/**
+ * Path a display connects to when it wants the relay to pick its code.
+ *
+ * Not a room code itself: codes reach a specific object through `/r/CODE`, and
+ * at this point there is no code yet. `MINT_PATH` is reserved, so it can never
+ * collide with a real room.
+ */
+const MINT_PATH = "/new";
+
+/** How many candidate codes to try before admitting defeat. */
+const MINT_ATTEMPTS = 5;
+
 /** Room code from `/r/CODE`, falling back to `?room=CODE`. */
 function roomCodeFrom(url: URL): string | null {
   const path = url.pathname.split("/").filter(Boolean);
   const fromPath = path[0] === "r" ? path[1] : undefined;
   const code = (fromPath ?? url.searchParams.get("room") ?? "").toUpperCase();
   return ROOM_CODE.test(code) ? code : null;
+}
+
+/**
+ * Assigns a room code by claiming one, rather than looking one up.
+ *
+ * A registry of taken codes would be a single object every room creation has to
+ * pass through — one thread, one datacenter, and the global room table this
+ * architecture exists to avoid. Instead each candidate code is offered to the
+ * object that *would* own it. A Durable Object is single-threaded, so "am I
+ * already hosting?" is atomic without any coordination, and the work spreads
+ * across the keyspace instead of piling onto one object.
+ *
+ * The claim rides along with the WebSocket upgrade, so a display still opens
+ * exactly one connection and learns its code from `ROOM_CREATED`.
+ */
+async function mintRoom(request: Request, env: Env): Promise<Response> {
+  for (let attempt = 0; attempt < MINT_ATTEMPTS; attempt++) {
+    const candidate = generateRoomCode();
+    const headers = new Headers(request.headers);
+    headers.set(ASSIGNED_CODE_HEADER, candidate);
+
+    const stub = env.ROOMS.get(env.ROOMS.idFromName(candidate));
+    const response = await stub.fetch(
+      new Request(request.url, { headers, method: request.method }),
+    );
+
+    // 409 means that object is already hosting a room, so the code is taken.
+    if (response.status !== 409) return response;
+  }
+  return new Response("Could not allocate a room code", { status: 503 });
 }
 
 export default {
@@ -66,8 +111,9 @@ export default {
       return new Response("Couch Kit relay", { status: 200 });
     }
 
-    const code = roomCodeFrom(url);
-    if (code === null) {
+    const minting = url.pathname === MINT_PATH;
+    const code = minting ? null : roomCodeFrom(url);
+    if (!minting && code === null) {
       return new Response("Missing or invalid room code", { status: 400 });
     }
 
@@ -83,10 +129,12 @@ export default {
       }
     }
 
+    if (minting) return mintRoom(request, env);
+
     // idFromName maps a room code to a stable object. The object exists
     // whether or not a display has created the room yet; an early joiner just
     // gets ROOM_NOT_FOUND from the empty room, exactly as before.
-    const stub = env.ROOMS.get(env.ROOMS.idFromName(code));
+    const stub = env.ROOMS.get(env.ROOMS.idFromName(code as string));
     return stub.fetch(request);
   },
 };

--- a/services/relay-worker/src/room.ts
+++ b/services/relay-worker/src/room.ts
@@ -15,11 +15,25 @@
 
 import { RelayRooms, type RelayConnection } from "../../relay/src/rooms";
 
+/**
+ * Header carrying a candidate room code from the router to the object that
+ * would own it. Declared here, with the object that answers it, because the
+ * router already imports this module.
+ */
+export const ASSIGNED_CODE_HEADER = "X-Assigned-Room";
+
 /** Per-socket state that must outlive hibernation. */
 interface Attachment {
   peerId: string;
   roomId?: string;
   role?: "host" | "player";
+  /**
+   * Code the router claimed for this socket, before the core has seen a
+   * `CREATE_ROOM`. Kept on the socket rather than in storage so an object that
+   * hibernates and wakes still knows what it was called, with no writes and
+   * nothing to clean up.
+   */
+  assignedCode?: string;
 }
 
 export class RelayRoom implements DurableObject {
@@ -37,7 +51,12 @@ export class RelayRoom implements DurableObject {
   private rooms(): RelayRooms {
     if (this.core) return this.core;
 
-    const core = new RelayRooms({ maxRooms: 1 });
+    // The core's default minting scans a table of every room, which a single
+    // room cannot do. The router already claimed a code for us, so hand that
+    // back instead.
+    const core = new RelayRooms({ maxRooms: 1 }, Date.now, () =>
+      this.claimedCode(),
+    );
     const entries: {
       conn: RelayConnection;
       roomId: string;
@@ -58,6 +77,27 @@ export class RelayRoom implements DurableObject {
 
     this.core = core;
     return core;
+  }
+
+  /** The code the router claimed for this object, read back off the sockets. */
+  private claimedCode(): string | null {
+    for (const ws of this.ctx.getWebSockets()) {
+      const code = this.attachment(ws)?.assignedCode;
+      if (code) return code;
+    }
+    return null;
+  }
+
+  /**
+   * Whether this object already represents a live room.
+   *
+   * Hibernated sockets are still returned here, so a room that is merely idle
+   * — a lobby waiting for players — correctly counts as occupied. When the last
+   * socket goes, the object empties and its code becomes available again, which
+   * is what keeps the keyspace from filling up with nothing.
+   */
+  private occupied(): boolean {
+    return this.ctx.getWebSockets().length > 0;
   }
 
   private attachment(ws: WebSocket): Attachment | null {
@@ -86,13 +126,25 @@ export class RelayRoom implements DurableObject {
       return new Response("Expected WebSocket upgrade", { status: 426 });
     }
 
+    // A claim for a code this object cannot give out. Refusing here — before
+    // any socket is accepted — is the whole collision check: this object runs
+    // single-threaded, so no concurrent claim can slip between the test and
+    // the accept below.
+    const assignedCode = request.headers.get(ASSIGNED_CODE_HEADER);
+    if (assignedCode !== null && this.occupied()) {
+      return new Response("Room code taken", { status: 409 });
+    }
+
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
 
     // acceptWebSocket (not server.accept) is what opts this object into
     // hibernation: the runtime keeps the socket while evicting us.
     this.ctx.acceptWebSocket(server);
-    server.serializeAttachment({ peerId: crypto.randomUUID() } satisfies Attachment);
+    server.serializeAttachment({
+      peerId: crypto.randomUUID(),
+      ...(assignedCode !== null ? { assignedCode } : {}),
+    } satisfies Attachment);
 
     return new Response(null, { status: 101, webSocket: client });
   }

--- a/services/relay/src/rooms.ts
+++ b/services/relay/src/rooms.ts
@@ -79,6 +79,47 @@ export function normalizeRoomId(roomId: string): string {
   return roomId.toUpperCase();
 }
 
+/**
+ * Room-code alphabet: no O/0 or I/1, which people confuse when copying a code
+ * off a TV across the room.
+ */
+export const ROOM_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+/**
+ * Length of a minted room code. 32^6 ≈ 1.07e9, so even a relay hosting a
+ * million concurrent rooms leaves a blind guess ~0.1% likely to reach a live
+ * game. The code is the only credential a player needs, so the keyspace has to
+ * stay far larger than the number of live rooms.
+ */
+export const ROOM_CODE_LENGTH = 6;
+
+/**
+ * A random room code.
+ *
+ * Uses the CSPRNG rather than `Math.random`, whose output is predictable from
+ * previous draws — codes are guessable enough without handing out the sequence.
+ * The alphabet is 32 characters and 256 is a whole multiple of it, so taking
+ * bytes modulo the length is unbiased.
+ */
+export function generateRoomCode(length: number = ROOM_CODE_LENGTH): string {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  let code = "";
+  for (const byte of bytes) {
+    code += ROOM_CODE_ALPHABET[byte % ROOM_CODE_ALPHABET.length];
+  }
+  return code;
+}
+
+/**
+ * How many codes to try before giving up on minting.
+ *
+ * Each attempt fails only on a collision, so with the keyspace far larger than
+ * the live-room count the first attempt essentially always wins; this bound
+ * only matters if a relay is somehow near capacity.
+ */
+const MINT_ATTEMPTS = 5;
+
 /** A single relay connection: an id plus a way to push a raw string to it. */
 export interface RelayConnection {
   id: string;
@@ -109,9 +150,35 @@ export class RelayRooms {
   private readonly limits: RelayLimits;
   private readonly now: () => number;
 
-  constructor(limits: Partial<RelayLimits> = {}, now: () => number = Date.now) {
+  /** Supplies the code for a `CREATE_ROOM` that did not name one. */
+  private readonly mintRoomCode: () => string | null;
+
+  constructor(
+    limits: Partial<RelayLimits> = {},
+    now: () => number = Date.now,
+    /**
+     * Overrides how an unnamed room gets its code.
+     *
+     * The default suits a relay that holds every room in one table: generate a
+     * code and check it against that table. A sharded relay cannot do that —
+     * a Cloudflare Durable Object *is* a single room and has no view of the
+     * others — so it claims the code before the socket ever reaches the core
+     * and passes the result in here.
+     */
+    mintRoomCode?: () => string | null,
+  ) {
     this.limits = { ...DEFAULT_LIMITS, ...limits };
     this.now = now;
+    this.mintRoomCode = mintRoomCode ?? (() => this.mintUnusedCode());
+  }
+
+  /** A code no room in this table is using, or `null` if repeated tries collided. */
+  private mintUnusedCode(): string | null {
+    for (let attempt = 0; attempt < MINT_ATTEMPTS; attempt++) {
+      const code = generateRoomCode();
+      if (!this.rooms.has(code)) return code;
+    }
+    return null;
   }
 
   get roomCount(): number {
@@ -239,8 +306,16 @@ export class RelayRooms {
   }
 
   private createRoom(conn: RelayConnection, rawRoomId?: string): void {
+    // No code named: the relay picks one. This is the path displays use — a
+    // client-chosen code cannot be checked for collisions before it is already
+    // on screen, and lets a caller squat on a code someone else is using.
     if (!rawRoomId) {
-      this.sendError(conn, RelayErrorCodes.MALFORMED, "Missing roomId");
+      const minted = this.mintRoomCode();
+      if (minted === null) {
+        this.sendError(conn, RelayErrorCodes.SERVER_BUSY, "Could not mint a room code");
+        return;
+      }
+      this.openRoom(conn, minted);
       return;
     }
     const roomId = normalizeRoomId(rawRoomId);
@@ -252,6 +327,11 @@ export class RelayRooms {
       this.sendError(conn, RelayErrorCodes.SERVER_BUSY, "Too many rooms");
       return;
     }
+    this.openRoom(conn, roomId);
+  }
+
+  /** Registers the room and tells the host its code. */
+  private openRoom(conn: RelayConnection, roomId: string): void {
     this.rooms.set(roomId, { host: conn, players: new Map() });
     this.membership.set(conn.id, { roomId, role: "host" });
     this.send(conn, {

--- a/services/relay/tests/rooms.test.ts
+++ b/services/relay/tests/rooms.test.ts
@@ -4,6 +4,9 @@ import {
   RelayMessageTypes,
   RelayErrorCodes,
   MAX_MESSAGE_BYTES,
+  generateRoomCode,
+  ROOM_CODE_ALPHABET,
+  ROOM_CODE_LENGTH,
   type RelayConnection,
 } from "../src/rooms";
 
@@ -357,5 +360,117 @@ describe("room code case", () => {
     player.sent.length = 0;
     rooms.handleMessage(host, JSON.stringify({ type: "DATA", data: "s" }));
     expect(player.sent[0]).toMatchObject({ type: RelayMessageTypes.DATA, data: "s" });
+  });
+});
+
+describe("minted room codes", () => {
+  const create = (rooms: RelayRooms, c: ReturnType<typeof conn>) =>
+    rooms.handleMessage(c, JSON.stringify({ type: "CREATE_ROOM" }));
+
+  test("a CREATE_ROOM with no code gets one from the relay", () => {
+    const rooms = new RelayRooms();
+    const host = conn("h");
+    create(rooms, host);
+
+    expect(rooms.roomCount).toBe(1);
+    expect(host.sent).toHaveLength(1);
+    expect(host.sent[0].type).toBe(RelayMessageTypes.ROOM_CREATED);
+    // The host has no other way to learn the code, so it must come back here.
+    expect(host.sent[0].roomId).toMatch(
+      new RegExp(`^[${ROOM_CODE_ALPHABET}]{${ROOM_CODE_LENGTH}}$`),
+    );
+  });
+
+  test("players can join a minted code", () => {
+    const rooms = new RelayRooms();
+    const host = conn("h");
+    create(rooms, host);
+    const code = host.sent[0].roomId;
+
+    const player = conn("p");
+    rooms.handleMessage(
+      player,
+      JSON.stringify({ type: "JOIN_ROOM", roomId: code }),
+    );
+    expect(player.sent[0]).toEqual({
+      type: RelayMessageTypes.ROOM_JOINED,
+      roomId: code,
+      peerId: "p",
+    });
+  });
+
+  test("minted codes are case-insensitive to join, like typed ones", () => {
+    const rooms = new RelayRooms();
+    const host = conn("h");
+    create(rooms, host);
+
+    const player = conn("p");
+    rooms.handleMessage(
+      player,
+      JSON.stringify({
+        type: "JOIN_ROOM",
+        roomId: host.sent[0].roomId.toLowerCase(),
+      }),
+    );
+    expect(player.sent[0].type).toBe(RelayMessageTypes.ROOM_JOINED);
+  });
+
+  test("does not hand the same code to two rooms", () => {
+    const rooms = new RelayRooms({ maxRooms: 200 });
+    const codes = new Set<string>();
+    for (let i = 0; i < 200; i++) {
+      const host = conn(`h${i}`);
+      create(rooms, host);
+      codes.add(host.sent[0].roomId);
+    }
+    expect(codes.size).toBe(200);
+    expect(rooms.roomCount).toBe(200);
+  });
+
+  test("a relay that cannot find a free code says so instead of colliding", () => {
+    // Mint hook that always returns a code already in use, standing in for a
+    // keyspace so full that every candidate collides.
+    const rooms = new RelayRooms({}, Date.now, () => null);
+    const host = conn("h");
+    create(rooms, host);
+
+    expect(rooms.roomCount).toBe(0);
+    expect(host.sent[0]).toMatchObject({
+      type: RelayMessageTypes.ERROR,
+      code: RelayErrorCodes.SERVER_BUSY,
+    });
+  });
+
+  test("a caller-supplied code still works, and still collides", () => {
+    const rooms = new RelayRooms();
+    rooms.handleMessage(
+      conn("h"),
+      JSON.stringify({ type: "CREATE_ROOM", roomId: "FIXED" }),
+    );
+    const second = conn("h2");
+    rooms.handleMessage(
+      second,
+      JSON.stringify({ type: "CREATE_ROOM", roomId: "FIXED" }),
+    );
+    expect(second.sent[0]).toMatchObject({
+      code: RelayErrorCodes.ROOM_EXISTS,
+    });
+  });
+});
+
+describe("generateRoomCode", () => {
+  test("uses only unambiguous characters", () => {
+    for (let i = 0; i < 200; i++) {
+      // O/0 and I/1 are the pairs people misread off a TV.
+      expect(generateRoomCode()).not.toMatch(/[O0I1]/);
+    }
+  });
+
+  test("does not repeat itself", () => {
+    const codes = new Set(
+      Array.from({ length: 1000 }, () => generateRoomCode()),
+    );
+    // Birthday collisions at 1000 draws from 32^6 are ~0.0005% likely.
+    expect(codes.size).toBe(1000);
   });
 });


### PR DESCRIPTION
Displays invented their own room codes. They cannot check them — only the relay knows which codes are live — so a collision showed up as a dead room whose code was already on the TV, with no retry anywhere.

`RelayDisplayHost`'s `roomId` is now optional:

```ts
const [roomCode, setRoomCode] = useState<string | null>(null);
new RelayDisplayHost({ url, onRoomCode: setRoomCode, reducer, initialState });
```

Six CSPRNG characters, alphabet without `O`/`0` or `I`/`1` — ~1.07 billion codes, so the keyspace stays far larger than the live-room count at any plausible scale.

## Why not a registry of taken codes

It would be one object in the path of every room creation — single-threaded, pinned to one datacenter, and precisely the global room table the Workers relay was built to avoid.

Instead the router offers a candidate to the Durable Object that *would* own it. That object is single-threaded, so "am I already hosting?" is atomic with no coordination, and load spreads across the keyspace. Two things fall out: the claim rides along with the WebSocket upgrade (**no extra round trip**), and a code frees itself when its object empties (**no storage, no alarms, nothing to leak**).

## Divergence

None. Room codes exist only on the relay path; the LAN/TV path (`@couch-kit/host`) has no codes at all. Both relays share one generator and one `CREATE_ROOM` flow — only the collision check differs, matching each architecture. No new packages.

Games get **smaller**: each display currently hand-rolls its own `Math.random` generator, and those all get deleted once this publishes.

## Verification

Against **both** relay implementations, using the real `RelayDisplayHost`:

| | |
|---|---|
| Mints distinct 6-char codes | ✅ |
| Phone joins a minted code, typed lowercase | ✅ |
| DATA routes end to end | ✅ |
| Collision → retry → distinct code | ✅ forced |
| Every candidate taken → 503, never a live room | ✅ forced |
| Code frees when the host leaves | ✅ `ROOM_NOT_FOUND` |

The two collision rows were forced by temporarily pinning the generator, since random codes will not collide on their own.

Typecheck, tests (8 new relay-core + 6 new display), coverage gate, and builds all pass locally. Display coverage went 88% → 97.67%.

## Breaking

Additive for callers. A display that omits `roomId` needs a relay with this change; against an older relay it gets `MALFORMED`. Both bundled relays are updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)