### PR TITLE
fix(relay): close the socket when a join names a room that does not exist

### DIFF
--- a/services/relay-worker/src/room.ts
+++ b/services/relay-worker/src/room.ts
@@ -160,7 +160,7 @@ export class RelayRoom implements DurableObject {
       typeof message === "string" ? message : new TextDecoder().decode(message);
 
     const core = this.rooms();
-    const keepOpen = core.handleMessage(this.connection(ws, att.peerId), raw);
+    const close = core.handleMessage(this.connection(ws, att.peerId), raw);
 
     // The role is only known once CREATE_ROOM / JOIN_ROOM has been handled.
     // Persist it so a wake can rebuild the routing table.
@@ -173,8 +173,11 @@ export class RelayRoom implements DurableObject {
       } satisfies Attachment);
     }
 
-    // A connection that trips the rate limit is dropped to shed abusive load.
-    if (!keepOpen) ws.close(1008, "Rate limited");
+    // Abusive load and dead-end joins are both shed by closing the socket. This
+    // matters more here than on the Bun relay: a join against a code no display
+    // ever created still routes to a Durable Object, and leaving that socket
+    // open would keep the object alive for a room that does not exist.
+    if (close) ws.close(close.code, close.reason);
   }
 
   async webSocketClose(

--- a/services/relay/src/rooms.ts
+++ b/services/relay/src/rooms.ts
@@ -39,6 +39,23 @@ export const RelayErrorCodes = {
 /** Matches `@couch-kit/runtime`'s `DEFAULT_MAX_MESSAGE_BYTES`. */
 export const MAX_MESSAGE_BYTES = 256 * 1024;
 
+/** RFC 6455 "policy violation" — the client did something it isn't allowed to. */
+export const RELAY_CLOSE_POLICY = 1008;
+
+/**
+ * A close the transport should perform after the core has finished with a
+ * message.
+ *
+ * The core cannot close sockets itself — it has no transport — so it says what
+ * should happen and `server.ts` / `room.ts` do it.
+ */
+export interface RelayClose {
+  /** WebSocket close code. */
+  code: number;
+  /** Human-readable close reason, for logs and devtools. */
+  reason: string;
+}
+
 /**
  * Abuse-mitigation limits for a public relay. All in-memory and per-process,
  * matching the single-instance deployment model. Defaults are generous for
@@ -227,18 +244,19 @@ export class RelayRooms {
   /**
    * Route one raw inbound message from `conn`.
    *
-   * @returns `false` when the connection has abused the rate limit and the
-   *   transport should close it; `true` to keep it open.
+   * @returns `null` to keep the connection open, or the close the transport
+   *   should perform. The error frame is always sent first, so a client learns
+   *   *why* before the socket goes.
    */
-  handleMessage(conn: RelayConnection, raw: string): boolean {
+  handleMessage(conn: RelayConnection, raw: string): RelayClose | null {
     if (!this.allow(conn.id)) {
       this.sendError(conn, RelayErrorCodes.RATE_LIMITED, "Too many messages");
-      return false;
+      return { code: RELAY_CLOSE_POLICY, reason: "Rate limited" };
     }
 
     if (byteLength(raw) > MAX_MESSAGE_BYTES) {
       this.sendError(conn, RelayErrorCodes.MESSAGE_TOO_LARGE, "Message too large");
-      return true;
+      return null;
     }
 
     let msg: { type?: string; roomId?: string; to?: string; data?: string };
@@ -246,7 +264,7 @@ export class RelayRooms {
       msg = JSON.parse(raw);
     } catch {
       this.sendError(conn, RelayErrorCodes.MALFORMED, "Invalid JSON");
-      return true;
+      return null;
     }
 
     switch (msg.type) {
@@ -254,15 +272,14 @@ export class RelayRooms {
         this.createRoom(conn, msg.roomId);
         break;
       case RelayMessageTypes.JOIN_ROOM:
-        this.joinRoom(conn, msg.roomId);
-        break;
+        return this.joinRoom(conn, msg.roomId);
       case RelayMessageTypes.DATA:
         this.routeData(conn, msg.data, msg.to);
         break;
       default:
         this.sendError(conn, RelayErrorCodes.MALFORMED, "Unknown message type");
     }
-    return true;
+    return null;
   }
 
   /**
@@ -341,20 +358,32 @@ export class RelayRooms {
     });
   }
 
-  private joinRoom(conn: RelayConnection, rawRoomId?: string): void {
+  /**
+   * @returns the close to perform, or `null` to keep the socket open. A join
+   *   against a room that does not exist is terminal: the code is wrong and no
+   *   later message on this socket can fix it. Closing keeps a mistyped or
+   *   sprayed code from parking a connection — and, on the Workers relay, from
+   *   holding open a Durable Object for a room that was never created.
+   */
+  private joinRoom(
+    conn: RelayConnection,
+    rawRoomId?: string,
+  ): RelayClose | null {
     if (!rawRoomId) {
       this.sendError(conn, RelayErrorCodes.MALFORMED, "Missing roomId");
-      return;
+      return null;
     }
     const roomId = normalizeRoomId(rawRoomId);
     const room = this.rooms.get(roomId);
     if (!room) {
       this.sendError(conn, RelayErrorCodes.ROOM_NOT_FOUND, "Room not found");
-      return;
+      return { code: RELAY_CLOSE_POLICY, reason: "Room not found" };
     }
     if (room.players.size >= this.limits.maxPlayersPerRoom) {
+      // Not terminal, unlike a bad code: a slot can open up, so let the client
+      // decide whether to wait.
       this.sendError(conn, RelayErrorCodes.ROOM_FULL, "Room is full");
-      return;
+      return null;
     }
     room.players.set(conn.id, conn);
     this.membership.set(conn.id, { roomId, role: "player" });
@@ -368,6 +397,7 @@ export class RelayRooms {
       roomId,
       peerId: conn.id,
     });
+    return null;
   }
 
   private routeData(conn: RelayConnection, data?: string, to?: string): void {

--- a/services/relay/src/server.ts
+++ b/services/relay/src/server.ts
@@ -73,12 +73,13 @@ const server = Bun.serve<SocketData, undefined>({
     },
     message(ws, message) {
       if (!ws.data.conn) return;
-      const keepOpen = rooms.handleMessage(
+      const close = rooms.handleMessage(
         ws.data.conn,
         typeof message === "string" ? message : message.toString(),
       );
-      // A connection that trips the rate limit is dropped to shed abusive load.
-      if (!keepOpen) ws.close(1008, "Rate limited");
+      // Abusive load and dead-end joins are both shed by closing the socket;
+      // the core already sent the matching ERROR frame.
+      if (close) ws.close(close.code, close.reason);
     },
     close(ws) {
       const next = (ipCounts.get(ws.data.ip) ?? 1) - 1;

--- a/services/relay/tests/rooms.test.ts
+++ b/services/relay/tests/rooms.test.ts
@@ -45,11 +45,30 @@ describe("RelayRooms", () => {
     expect(h2.sent[0].code).toBe(RelayErrorCodes.ROOM_EXISTS);
   });
 
-  test("joining unknown room errors", () => {
+  test("joining unknown room errors and closes the socket", () => {
     const rooms = new RelayRooms();
     const p = conn("p");
-    rooms.handleMessage(p, JSON.stringify({ type: "JOIN_ROOM", roomId: "nope" }));
+    const close = rooms.handleMessage(
+      p,
+      JSON.stringify({ type: "JOIN_ROOM", roomId: "nope" }),
+    );
+    // The error frame goes first, so the client can show "wrong code" rather
+    // than a bare disconnect.
     expect(p.sent[0].code).toBe(RelayErrorCodes.ROOM_NOT_FOUND);
+    expect(close).toEqual({ code: 1008, reason: "Room not found" });
+  });
+
+  test("a full room errors but stays open", () => {
+    const rooms = new RelayRooms({ maxPlayersPerRoom: 1 });
+    rooms.handleMessage(conn("h"), JSON.stringify({ type: "CREATE_ROOM", roomId: "R" }));
+    rooms.handleMessage(conn("p1"), JSON.stringify({ type: "JOIN_ROOM", roomId: "R" }));
+    const p2 = conn("p2");
+    const close = rooms.handleMessage(
+      p2,
+      JSON.stringify({ type: "JOIN_ROOM", roomId: "R" }),
+    );
+    expect(p2.sent[0].code).toBe(RelayErrorCodes.ROOM_FULL);
+    expect(close).toBeNull();
   });
 
   test("player join notifies host and joiner", () => {
@@ -166,14 +185,14 @@ describe("RelayRooms", () => {
     expect(c.sent[0].code).toBe(RelayErrorCodes.MALFORMED);
   });
 
-  test("handleMessage returns true for well-behaved traffic", () => {
+  test("handleMessage returns null for well-behaved traffic", () => {
     const rooms = new RelayRooms();
     const host = conn("h");
-    const keepOpen = rooms.handleMessage(
+    const close = rooms.handleMessage(
       host,
       JSON.stringify({ type: "CREATE_ROOM", roomId: "R" }),
     );
-    expect(keepOpen).toBe(true);
+    expect(close).toBeNull();
   });
 
   test("exceeding the message rate limit errors and signals disconnect", () => {
@@ -181,11 +200,14 @@ describe("RelayRooms", () => {
     const c = conn("c");
     // Unknown-type messages still count toward the rate limit.
     const noop = JSON.stringify({ type: "NOPE" });
-    expect(rooms.handleMessage(c, noop)).toBe(true);
-    expect(rooms.handleMessage(c, noop)).toBe(true);
-    expect(rooms.handleMessage(c, noop)).toBe(true);
+    expect(rooms.handleMessage(c, noop)).toBeNull();
+    expect(rooms.handleMessage(c, noop)).toBeNull();
+    expect(rooms.handleMessage(c, noop)).toBeNull();
     // 4th within the window trips the limit.
-    expect(rooms.handleMessage(c, noop)).toBe(false);
+    expect(rooms.handleMessage(c, noop)).toEqual({
+      code: 1008,
+      reason: "Rate limited",
+    });
     expect(c.sent.at(-1).code).toBe(RelayErrorCodes.RATE_LIMITED);
   });
 
@@ -197,10 +219,10 @@ describe("RelayRooms", () => {
     );
     const c = conn("c");
     const noop = JSON.stringify({ type: "NOPE" });
-    expect(rooms.handleMessage(c, noop)).toBe(true);
-    expect(rooms.handleMessage(c, noop)).toBe(true);
+    expect(rooms.handleMessage(c, noop)).toBeNull();
+    expect(rooms.handleMessage(c, noop)).toBeNull();
     t = 1001; // old hits fall out of the window
-    expect(rooms.handleMessage(c, noop)).toBe(true);
+    expect(rooms.handleMessage(c, noop)).toBeNull();
   });
 
   test("room creation is capped at maxRooms", () => {
@@ -304,7 +326,7 @@ describe("RelayRooms", () => {
     rooms.handleMessage(c, noop);
     rooms.handleClose(c);
     // Fresh budget after reconnect (same id): first message is allowed again.
-    expect(rooms.handleMessage(c, noop)).toBe(true);
+    expect(rooms.handleMessage(c, noop)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Problem

Noticed while testing: hitting **Join** with a mistyped code created a Durable Object for that code.

`JOIN_ROOM` against an unknown code sends `ROOM_NOT_FOUND` and then leaves the connection open, waiting for the client to hang up. No message arriving later on that socket can make the room exist, so the wait is unbounded and entirely at the client's discretion.

On the Workers relay that's more than an idle connection. Room codes address Durable Objects via `idFromName`, so a join instantiates the object for that code whether or not a display ever created the room. Holding the socket open holds the object with it — a client spraying codes can park arbitrarily many rooms that don't exist.

Worth stating what this is *not*: `RelayRoom` never touches `ctx.storage`, and per Cloudflare's docs an object whose storage is empty at shutdown ceases to exist. Nothing accumulates and there's nothing to clean up. The cost is held connections and DO compute, not storage.

## Change

`handleMessage` returns a `RelayClose | null` directive instead of a `boolean`. The boolean could only express one close, with its code and reason hardcoded at each transport; the directive lets the core say *which* close to perform, and `server.ts` / `room.ts` just carry it out.

- Unknown room → `ERROR` frame first, then close `1008 "Room not found"`. Error-before-close means a client still learns *why*.
- `ROOM_FULL` deliberately stays open: that room exists and a slot can free up, so waiting is the client's call.

Both relays get the fix since they share the core, but it matters asymmetrically — on Bun it frees a connection slot, on Workers it releases the Durable Object.

## No client-visible change

`relay-transport.ts` already closes on any `ERROR` and reports `POLICY_CLOSE_CODE` with the relay's code as the reason. The `ERROR` frame precedes the close frame, so `pendingCloseCode` is set first and still wins in `onclose` — a mistyped code surfaces as `ROOM_NOT_FOUND`, not a bare 1008. The server-side close covers clients that aren't this transport, which is the abuse case.

## Testing

- `services/relay`: 34 pass. Updated the true/false assertions; added coverage for unknown-room-closes and full-room-stays-open.
- `bun run test`: 244 pass / 0 fail across packages.
- `tsc --noEmit` clean on both `services/relay-worker` and the workspace.

No changeset: `services/*` are not published packages and no public API changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)