### PR TITLE
feat: cut relay traffic with ping backoff and batched projected updates

### DIFF
--- a/.changeset/olive-rivers-gather.md
+++ b/.changeset/olive-rivers-gather.md
@@ -1,0 +1,29 @@
+---
+"@couch-kit/runtime": minor
+"@couch-kit/display": minor
+"@couch-kit/client": minor
+---
+
+Send a projected state update as one relay frame instead of one per player
+
+A game with a `project` function sends every player their own view, which meant
+one WebSocket frame per player for every state change. Relays bill and
+rate-limit per inbound frame, so a four-player table paid four messages for one
+update and spent four of the display's 30-per-second budget.
+
+`GameRuntimeTransport` gains an optional `sendMany(entries)`. When a transport
+implements it, the runtime hands over the whole projected batch at once;
+transports that do not — the LAN WebSocket path — keep receiving one `send` per
+connection and are unaffected.
+
+`RelayDisplayHost` implements it with a new `DATA_MULTI` envelope carrying a
+peer-id-to-payload map, which the relay unpacks into ordinary `DATA` frames.
+Phones need no update — nothing on the client side can tell a batched update
+from a unicast one. If the combined frame would exceed the relay's 256KB
+ceiling, the display falls back to individual frames rather than send something
+the relay would drop.
+
+Relays must be updated before displays: both bundled implementations
+(`services/relay`, `services/relay-worker`) understand `DATA_MULTI`, and an
+older relay answers it with `MALFORMED`. The type is host-only — a phone sending
+it is rejected, so it cannot be used to reach another phone directly.

--- a/.changeset/quiet-moons-listen.md
+++ b/.changeset/quiet-moons-listen.md
@@ -1,0 +1,24 @@
+---
+"@couch-kit/client": minor
+"@couch-kit/core": minor
+---
+
+Back the time-sync ping off to 30s once the clock estimate settles
+
+`useGameClient`'s clock sync pinged every 5 seconds for the life of the
+connection. It now starts there and doubles to a 30-second ceiling
+(`MAX_SYNC_INTERVAL`), resetting to the fast interval whenever a new socket is
+established, including after a reconnect.
+
+The first few pings are what converge the offset; the clock difference they
+measure does not drift on a human timescale, so the fast interval stops earning
+its cost within about a minute. On a relay transport it is not free: each ping
+is a message in and a `PONG` back out, and pings are the only traffic an idle
+table generates at all. A four-player lobby went from 5,760 relay messages an
+hour to under 1,000 while sitting untouched.
+
+`rtt` and `getServerTime()` are unchanged in accuracy — both are updated by the
+same `PONG` handling as before, just less often once settled. Games needing the
+old cadence can dispatch their own pings; the constants
+(`DEFAULT_SYNC_INTERVAL`, `MAX_SYNC_INTERVAL`, `SYNC_BACKOFF_FACTOR`) are
+exported from `@couch-kit/core`.

--- a/packages/client/src/relay-protocol.ts
+++ b/packages/client/src/relay-protocol.ts
@@ -28,6 +28,8 @@ export const RelayMessageTypes = {
   PEER_LEFT: "PEER_LEFT",
   /** Bidirectional: carries an opaque Couch Kit JSON message as `data`. */
   DATA: "DATA",
+  /** Display → relay: one frame carrying a different payload per phone. */
+  DATA_MULTI: "DATA_MULTI",
   /** Relay → client: a protocol/room error. */
   ERROR: "ERROR",
 } as const;
@@ -109,6 +111,23 @@ export interface DataMessage {
   data: string;
 }
 
+/**
+ * Display → relay: one envelope carrying a different payload per phone.
+ *
+ * `payloads` maps a phone's `peerId` to the already-serialized Couch Kit
+ * message for that phone. The relay unpacks it into ordinary
+ * {@link DataMessage} frames, so phones never see this type — it exists purely
+ * so a projected game costs one inbound relay message per state change instead
+ * of one per player. Peer ids the room does not know are skipped.
+ *
+ * Host-only: the relay rejects it from a phone.
+ */
+export interface DataMultiMessage {
+  type: typeof RelayMessageTypes.DATA_MULTI;
+  roomId: string;
+  payloads: Record<string, string>;
+}
+
 /** Relay → client: a protocol/room error. */
 export interface RelayErrorMessage {
   type: typeof RelayMessageTypes.ERROR;
@@ -118,9 +137,7 @@ export interface RelayErrorMessage {
 
 /** Any message a client may send to the relay. */
 export type RelayClientMessage =
-  | CreateRoomMessage
-  | JoinRoomMessage
-  | DataMessage;
+  CreateRoomMessage | JoinRoomMessage | DataMessage | DataMultiMessage;
 
 /** Any message the relay may send to a client. */
 export type RelayServerMessage =

--- a/packages/client/src/time-sync.ts
+++ b/packages/client/src/time-sync.ts
@@ -3,6 +3,8 @@ import {
   MessageTypes,
   generateId,
   DEFAULT_SYNC_INTERVAL,
+  MAX_SYNC_INTERVAL,
+  SYNC_BACKOFF_FACTOR,
   MAX_PENDING_PINGS,
 } from "@couch-kit/core";
 import { TransportReadyState, type ClientTransport } from "./transport";
@@ -36,6 +38,22 @@ export function calculateTimeSync(
   const offset = expectedServerTime - clientReceiveTime;
 
   return { offset, rtt };
+}
+
+/**
+ * The interval to wait before the next PING, given the one just used.
+ *
+ * Grows geometrically to {@link MAX_SYNC_INTERVAL}: the first pings after
+ * connecting are what converge the offset, and re-measuring it every few
+ * seconds forever buys nothing — the clock difference does not move, while on a
+ * relay transport each ping is a billed message in both directions and the only
+ * traffic an idle table generates at all.
+ *
+ * @param current - Interval (ms) used for the ping just sent.
+ * @returns The next interval, capped at {@link MAX_SYNC_INTERVAL}.
+ */
+export function nextSyncInterval(current: number): number {
+  return Math.min(current * SYNC_BACKOFF_FACTOR, MAX_SYNC_INTERVAL);
 }
 
 /**
@@ -85,8 +103,18 @@ export function useServerTime(socket: ClientTransport | null) {
   );
 
   // Periodic Sync
+  //
+  // The interval backs off from DEFAULT_SYNC_INTERVAL to MAX_SYNC_INTERVAL
+  // rather than staying fast forever: the first few pings are what converge the
+  // offset, and after that we are re-measuring a clock difference that does not
+  // move. A self-rescheduling timeout is used instead of setInterval because
+  // the delay changes between ticks. Backoff state lives inside the effect, so
+  // a new socket — including a reconnect — starts fast again.
   useEffect(() => {
     if (!socket || socket.readyState !== TransportReadyState.OPEN) return;
+
+    let delay = DEFAULT_SYNC_INTERVAL;
+    let timer: ReturnType<typeof setTimeout> | null = null;
 
     const sync = () => {
       // Prevent unbounded growth if PONGs are lost
@@ -105,13 +133,17 @@ export function useServerTime(socket: ClientTransport | null) {
           payload: { id, timestamp },
         }),
       );
+
+      delay = nextSyncInterval(delay);
+      timer = setTimeout(sync, delay);
     };
 
     // Initial sync
     sync();
 
-    const interval = setInterval(sync, DEFAULT_SYNC_INTERVAL);
-    return () => clearInterval(interval);
+    return () => {
+      if (timer !== null) clearTimeout(timer);
+    };
   }, [socket]);
 
   return { getServerTime, rtt: timeSync.rtt, handlePong };

--- a/packages/client/tests/time-sync.test.ts
+++ b/packages/client/tests/time-sync.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { calculateTimeSync } from "../src/time-sync";
+import { DEFAULT_SYNC_INTERVAL, MAX_SYNC_INTERVAL } from "@couch-kit/core";
+import { calculateTimeSync, nextSyncInterval } from "../src/time-sync";
 
 describe("Time Synchronization", () => {
   test("calculateTimeSync should determine correct offset", () => {
@@ -8,7 +9,7 @@ describe("Time Synchronization", () => {
     // Server receives (instantly for math simplicity) at T=2000 (so server is +1000 ahead)
     // Server processes instantly
     // Client receives pong at T=1020 (RTT = 20ms)
-    
+
     const clientSend = 1000;
     const clientReceive = 1020;
     const serverTimeReported = 2010; // Server time when it processed it (approx middle)
@@ -20,7 +21,11 @@ describe("Time Synchronization", () => {
     // Actual Client Time (at client receive) = 1020
     // Offset = 2020 - 1020 = 1000
 
-    const { offset, rtt } = calculateTimeSync(clientSend, clientReceive, serverTimeReported);
+    const { offset, rtt } = calculateTimeSync(
+      clientSend,
+      clientReceive,
+      serverTimeReported,
+    );
 
     expect(rtt).toBe(20);
     expect(offset).toBe(1000);
@@ -31,12 +36,49 @@ describe("Time Synchronization", () => {
     const clientReceive = 2020;
     const serverTimeReported = 1010; // Server is ~1000ms behind
 
-    const { offset, rtt } = calculateTimeSync(clientSend, clientReceive, serverTimeReported);
+    const { offset, rtt } = calculateTimeSync(
+      clientSend,
+      clientReceive,
+      serverTimeReported,
+    );
 
     expect(rtt).toBe(20);
     // Expected Server Time = 1010 + 10 = 1020
     // Client Time = 2020
     // Offset = 1020 - 2020 = -1000
     expect(offset).toBe(-1000);
+  });
+});
+
+describe("sync interval backoff", () => {
+  test("grows from the default and settles at the ceiling", () => {
+    const schedule: number[] = [];
+    let interval = DEFAULT_SYNC_INTERVAL;
+    for (let i = 0; i < 5; i++) {
+      schedule.push(interval);
+      interval = nextSyncInterval(interval);
+    }
+
+    expect(schedule).toEqual([5_000, 10_000, 20_000, 30_000, 30_000]);
+  });
+
+  test("never exceeds the ceiling", () => {
+    expect(nextSyncInterval(MAX_SYNC_INTERVAL)).toBe(MAX_SYNC_INTERVAL);
+  });
+
+  test("a settled table pings far less than the old fixed interval", () => {
+    // The saving is the whole point: pings are the only traffic an idle table
+    // generates, and each one costs a billed relay message in each direction.
+    let elapsed = 0;
+    let interval = DEFAULT_SYNC_INTERVAL;
+    let pings = 1; // the immediate sync on connect
+    while (elapsed + interval <= 3_600_000) {
+      elapsed += interval;
+      pings++;
+      interval = nextSyncInterval(interval);
+    }
+
+    const fixed = 3_600_000 / DEFAULT_SYNC_INTERVAL;
+    expect(pings).toBeLessThan(fixed / 5);
   });
 });

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -23,8 +23,22 @@ export const DEFAULT_BASE_DELAY = 1000;
 /** Default maximum delay (ms) cap for reconnection backoff. */
 export const DEFAULT_MAX_DELAY = 10000;
 
-/** Default time sync ping interval (ms). */
+/** Default time sync ping interval (ms) — the interval a fresh socket starts at. */
 export const DEFAULT_SYNC_INTERVAL = 5000;
+
+/**
+ * Ceiling (ms) the time-sync interval backs off to once the clock estimate has
+ * settled.
+ *
+ * Pings are the only traffic an idle table generates, and on a relay transport
+ * every one of them is a billed message for the ping *and* the host's pong. The
+ * offset they measure is a clock difference that does not drift on a human
+ * timescale, so the fast interval only earns its cost right after connecting.
+ */
+export const MAX_SYNC_INTERVAL = 30000;
+
+/** Multiplier applied to the time-sync interval after each ping, up to {@link MAX_SYNC_INTERVAL}. */
+export const SYNC_BACKOFF_FACTOR = 2;
 
 /** Maximum number of outstanding pings before cleanup. */
 export const MAX_PENDING_PINGS = 50;

--- a/packages/display/src/relay-display-host.ts
+++ b/packages/display/src/relay-display-host.ts
@@ -2,6 +2,7 @@ import {
   GameHostRuntime,
   frameByteLength,
   DEFAULT_MAX_MESSAGE_BYTES,
+  type AddressedMessage,
   type GameHostRuntimeConfig,
   type GameRuntimeTransport,
 } from "@couch-kit/runtime";
@@ -19,8 +20,10 @@ import {
  * object used by the RN-TV host) and the shared relay coordinates; the display
  * host owns the authoritative runtime and the relay socket.
  */
-export interface RelayDisplayHostOptions<S extends IGameState, A extends IAction>
-  extends GameHostRuntimeConfig<S, A> {
+export interface RelayDisplayHostOptions<
+  S extends IGameState,
+  A extends IAction,
+> extends GameHostRuntimeConfig<S, A> {
   /** WebSocket URL of the shared relay server. */
   url: string;
   /**
@@ -103,9 +106,9 @@ export class RelayDisplayHost<S extends IGameState, A extends IAction> {
       );
 
     const transport: GameRuntimeTransport = {
-      send: (connectionId, message) =>
-        this.sendEnvelope(message, connectionId),
+      send: (connectionId, message) => this.sendEnvelope(message, connectionId),
       broadcast: (message) => this.sendEnvelope(message),
+      sendMany: (entries) => this.sendMultiEnvelope(entries),
     };
     this.runtime.setTransport(transport);
   }
@@ -134,6 +137,42 @@ export class RelayDisplayHost<S extends IGameState, A extends IAction> {
     this.runtime.setTransport(null);
     this.runtime.stop();
     this.ws.close();
+  }
+
+  /**
+   * Sends per-connection messages as one `DATA_MULTI` frame, which the relay
+   * unpacks into an ordinary `DATA` frame per phone.
+   *
+   * A projected game re-sends every player's view on every state change, so on
+   * a four-player table this is the difference between one billed relay message
+   * and four — and between one and four against the relay's per-connection rate
+   * limit, which the display shares across all its fan-out.
+   *
+   * Falls back to individual sends if the combined frame would exceed the
+   * relay's message ceiling: N views in one envelope is N times the bytes, and
+   * a frame the relay rejects delivers nothing to anyone. Splitting costs
+   * messages; being dropped costs the game.
+   */
+  private sendMultiEnvelope(entries: readonly AddressedMessage[]): void {
+    const payloads: Record<string, string> = {};
+    for (const { connectionId, message } of entries) {
+      payloads[connectionId] = JSON.stringify(message);
+    }
+
+    const frame = JSON.stringify({
+      type: RelayMessageTypes.DATA_MULTI,
+      roomId: this.assignedRoomId ?? undefined,
+      payloads,
+    });
+
+    if (frameByteLength(frame) > DEFAULT_MAX_MESSAGE_BYTES) {
+      for (const { connectionId, message } of entries) {
+        this.sendEnvelope(message, connectionId);
+      }
+      return;
+    }
+
+    this.ws.send(frame);
   }
 
   private sendEnvelope(message: HostMessage, to?: string): void {

--- a/packages/display/tests/relay-display-host.test.ts
+++ b/packages/display/tests/relay-display-host.test.ts
@@ -218,6 +218,101 @@ describe("RelayDisplayHost", () => {
   });
 });
 
+/**
+ * A projected game re-sends every player's own view on each state change. Those
+ * go out as one `DATA_MULTI` frame rather than one frame per player, because a
+ * relay bills and rate-limits per inbound frame.
+ */
+describe("projected state updates", () => {
+  interface HandState extends IGameState {
+    hands: Record<string, string>;
+  }
+
+  function makeProjectedHost(project: (s: HandState, id: string) => unknown) {
+    const host = new RelayDisplayHost<HandState, TestAction>({
+      url: "wss://relay.test",
+      roomId: "ROOM",
+      reducer: (state) => ({ ...state, hands: { ...state.hands } }),
+      initialState: { status: "lobby", players: {}, hands: { seat: "ACE" } },
+      project,
+      stateThrottleMs: 1,
+    });
+    return { host, ws: MockWebSocket.last! };
+  }
+
+  /** Brings a phone all the way to joined, so it is in `joinedConnections`. */
+  async function join(ws: MockWebSocket, peerId: string) {
+    ws.fromServer({ type: RelayMessageTypes.PEER_JOINED, roomId: "ROOM", peerId });
+    ws.fromServer({
+      type: RelayMessageTypes.DATA,
+      roomId: "ROOM",
+      from: peerId,
+      // A distinct secret per phone, or the second one resumes the first's
+      // session instead of taking a seat of its own.
+      data: JSON.stringify({
+        type: "JOIN",
+        payload: { secret: peerId.slice(-1).repeat(32), name: peerId },
+      }),
+    });
+    await flush();
+  }
+
+  const multiFrames = (ws: MockWebSocket) =>
+    ws.frames().filter((f) => f.type === RelayMessageTypes.DATA_MULTI);
+
+  test("two players cost one frame, keyed by peer id", async () => {
+    const { host, ws } = makeProjectedHost((state, id) => ({ ...state, me: id }));
+    ws.open();
+    await join(ws, "p1");
+    await join(ws, "p2");
+    ws.sent.length = 0;
+
+    host.dispatch({ type: "BUMP" });
+    await flush();
+
+    const frames = multiFrames(ws);
+    expect(frames).toHaveLength(1);
+    expect(Object.keys(frames[0].payloads).sort()).toEqual(["p1", "p2"]);
+    // And no per-player DATA frames alongside it.
+    expect(ws.dataMessages().filter((d) => d.msg.type === "STATE_UPDATE")).toEqual([]);
+  });
+
+  test("each payload carries that player's own projection", async () => {
+    const { host, ws } = makeProjectedHost((state, id) => ({ ...state, me: id }));
+    ws.open();
+    await join(ws, "p1");
+    await join(ws, "p2");
+    ws.sent.length = 0;
+
+    host.dispatch({ type: "BUMP" });
+    await flush();
+
+    const { payloads } = multiFrames(ws)[0];
+    // The projection is keyed off the player id, not the peer id, so assert the
+    // two phones got *different* views rather than guessing the id.
+    expect(payloads.p1).not.toEqual(payloads.p2);
+  });
+
+  test("falls back to per-player frames when the batch would be rejected", async () => {
+    // Each view fits the relay's 256KB ceiling; two in one envelope do not.
+    const bulk = "x".repeat(200 * 1024);
+    const { host, ws } = makeProjectedHost((state) => ({ ...state, bulk }));
+    ws.open();
+    await join(ws, "p1");
+    await join(ws, "p2");
+    ws.sent.length = 0;
+
+    host.dispatch({ type: "BUMP" });
+    await flush();
+
+    // Splitting costs an extra billed message; being dropped by the relay would
+    // cost the game.
+    expect(multiFrames(ws)).toHaveLength(0);
+    const updates = ws.dataMessages().filter((d) => d.msg.type === "STATE_UPDATE");
+    expect(updates.map((u) => u.to).sort()).toEqual(["p1", "p2"]);
+  });
+});
+
 describe("relay-assigned room codes", () => {
   /** A host that lets the relay pick the code. */
   function makeMintingHost() {

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -23,10 +23,27 @@ import {
   type JoinSessionPayload,
 } from "./session-manager.js";
 
+/** One connection's share of a {@link GameRuntimeTransport.sendMany} delivery. */
+export interface AddressedMessage {
+  connectionId: string;
+  message: HostMessage;
+}
+
 /** Minimal message-delivery surface required by the authoritative runtime. */
 export interface GameRuntimeTransport {
   send(connectionId: string, message: HostMessage): void;
   broadcast(message: HostMessage): void;
+  /**
+   * Delivers a batch of per-connection messages, for transports that can carry
+   * them in one frame.
+   *
+   * Optional: the runtime falls back to a {@link GameRuntimeTransport.send} per
+   * entry, which is what a plain LAN WebSocket transport wants anyway. It earns
+   * its keep on the relay, where each frame the display sends is separately
+   * billed and rate-limited, so a projected state update costs one message
+   * rather than one per player.
+   */
+  sendMany?(entries: readonly AddressedMessage[]): void;
 }
 
 /** Configuration shared by every authoritative Couch Kit host transport. */
@@ -404,27 +421,39 @@ export class GameHostRuntime<S extends IGameState, A extends IAction> {
   }
 
   private readonly broadcastState = (): void => {
-    if (!this.transport) return;
+    const transport = this.transport;
+    if (!transport) return;
 
     const actions = this.actionQueue;
     this.actionQueue = [];
     this.stateDirty = false;
 
     if (!this.config.project) {
-      this.transport.broadcast(createStateUpdateMessage(this.state, actions));
+      transport.broadcast(createStateUpdateMessage(this.state, actions));
       return;
     }
 
     // Projected games get one message per connection rather than a broadcast:
-    // a shared frame cannot carry different views. Costs N sends instead of 1,
-    // which is bounded by players-per-room.
+    // a shared frame cannot carry different views. Transports that can batch
+    // (see GameRuntimeTransport.sendMany) still put them on the wire as a
+    // single frame; the rest fall back to N sends, bounded by players-per-room.
+    const entries: AddressedMessage[] = [];
     for (const connectionId of this.joinedConnections) {
       const playerId = this.sessionManager.getPlayerIdForSocket(connectionId);
       if (!playerId) continue;
-      this.send(
+      entries.push({
         connectionId,
-        createStateUpdateMessage(this.viewFor(playerId), actions),
-      );
+        message: createStateUpdateMessage(this.viewFor(playerId), actions),
+      });
+    }
+    if (entries.length === 0) return;
+
+    if (transport.sendMany) {
+      transport.sendMany(entries);
+      return;
+    }
+    for (const { connectionId, message } of entries) {
+      this.send(connectionId, message);
     }
   };
 

--- a/packages/runtime/tests/runtime.test.ts
+++ b/packages/runtime/tests/runtime.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@couch-kit/core";
 import {
   GameHostRuntime,
+  type AddressedMessage,
   type GameHostRuntimeConfig,
   type GameRuntimeTransport,
 } from "../src/runtime";
@@ -542,8 +543,8 @@ describe("GameHostRuntime state projection", () => {
     const { runtime, transport } = createHandsRuntime(true);
     await joinHands(runtime, "conn-1");
 
-    const welcome = transport
-      .sent.get("conn-1")
+    const welcome = transport.sent
+      .get("conn-1")
       ?.find((m) => m.type === MessageTypes.WELCOME);
     const state = (welcome?.payload as { state: HandState }).state;
 
@@ -556,8 +557,8 @@ describe("GameHostRuntime state projection", () => {
     const { runtime, transport } = createHandsRuntime(true);
     await joinHands(runtime, "conn-1");
 
-    const welcome = transport
-      .sent.get("conn-1")
+    const welcome = transport.sent
+      .get("conn-1")
       ?.find((m) => m.type === MessageTypes.WELCOME);
     const { playerId, state } = welcome?.payload as {
       playerId: string;
@@ -592,12 +593,91 @@ describe("GameHostRuntime state projection", () => {
     const { runtime, transport } = createHandsRuntime(false);
     await joinHands(runtime, "conn-1");
 
-    const welcome = transport
-      .sent.get("conn-1")
+    const welcome = transport.sent
+      .get("conn-1")
       ?.find((m) => m.type === MessageTypes.WELCOME);
     const state = (welcome?.payload as { state: HandState }).state;
 
     // Games with no hidden information are unaffected.
     expect(state.hands.seat).toEqual(["ACE", "KING"]);
+  });
+
+  /**
+   * A projected update is one message per player. On a relay each of those is
+   * separately billed and rate-limited, so a transport that can carry the batch
+   * in one frame is offered the whole set at once.
+   */
+  describe("batched delivery", () => {
+    class BatchingTransport extends FakeTransport {
+      readonly batches: (readonly AddressedMessage[])[] = [];
+
+      sendMany(entries: readonly AddressedMessage[]): void {
+        this.batches.push(entries);
+        for (const { connectionId, message } of entries) {
+          this.send(connectionId, message);
+        }
+      }
+    }
+
+    async function joinTwo(transport: FakeTransport) {
+      const runtime = new GameHostRuntime<HandState, { type: "NOOP" }>(
+        {
+          initialState: handsInitial,
+          reducer: handsReducer,
+          stateThrottleMs: 0,
+          disconnectTimeout: 60_000,
+          project,
+        },
+        transport,
+      );
+      await joinHands(runtime, "conn-1");
+      await joinHands(runtime, "conn-2");
+      return runtime;
+    }
+
+    test("a projected update is offered to sendMany as one batch", async () => {
+      const transport = new BatchingTransport();
+      const runtime = await joinTwo(transport);
+
+      transport.batches.length = 0;
+      runtime.dispatch({ type: "NOOP" });
+      await flushBroadcast();
+
+      expect(transport.batches).toHaveLength(1);
+      expect(transport.batches[0]!.map((e) => e.connectionId).sort()).toEqual([
+        "conn-1",
+        "conn-2",
+      ]);
+    });
+
+    test("each entry still carries that connection's own view", async () => {
+      const transport = new BatchingTransport();
+      const runtime = await joinTwo(transport);
+
+      transport.batches.length = 0;
+      runtime.dispatch({ type: "NOOP" });
+      await flushBroadcast();
+
+      // Batching is a delivery detail; it must not leak one player's hand into
+      // the frame another player receives.
+      for (const { message } of transport.batches[0]!) {
+        const { newState } = message.payload as { newState: HandState };
+        expect(newState.hands.seat).toEqual(["HIDDEN", "HIDDEN"]);
+      }
+    });
+
+    test("a transport without sendMany still gets one send per connection", async () => {
+      const transport = new FakeTransport();
+      const runtime = await joinTwo(transport);
+
+      transport.sent.clear();
+      runtime.dispatch({ type: "NOOP" });
+      await flushBroadcast();
+
+      // The LAN WebSocket transport implements no batching and must be
+      // unaffected by the seam existing.
+      expect(transport.sent.get("conn-1")).toHaveLength(1);
+      expect(transport.sent.get("conn-2")).toHaveLength(1);
+    });
   });
 });

--- a/services/relay/src/rooms.ts
+++ b/services/relay/src/rooms.ts
@@ -22,6 +22,7 @@ export const RelayMessageTypes = {
   PEER_JOINED: "PEER_JOINED",
   PEER_LEFT: "PEER_LEFT",
   DATA: "DATA",
+  DATA_MULTI: "DATA_MULTI",
   ERROR: "ERROR",
 } as const;
 
@@ -255,11 +256,21 @@ export class RelayRooms {
     }
 
     if (byteLength(raw) > MAX_MESSAGE_BYTES) {
-      this.sendError(conn, RelayErrorCodes.MESSAGE_TOO_LARGE, "Message too large");
+      this.sendError(
+        conn,
+        RelayErrorCodes.MESSAGE_TOO_LARGE,
+        "Message too large",
+      );
       return null;
     }
 
-    let msg: { type?: string; roomId?: string; to?: string; data?: string };
+    let msg: {
+      type?: string;
+      roomId?: string;
+      to?: string;
+      data?: string;
+      payloads?: Record<string, string>;
+    };
     try {
       msg = JSON.parse(raw);
     } catch {
@@ -275,6 +286,9 @@ export class RelayRooms {
         return this.joinRoom(conn, msg.roomId);
       case RelayMessageTypes.DATA:
         this.routeData(conn, msg.data, msg.to);
+        break;
+      case RelayMessageTypes.DATA_MULTI:
+        this.routeMulti(conn, msg.payloads);
         break;
       default:
         this.sendError(conn, RelayErrorCodes.MALFORMED, "Unknown message type");
@@ -329,7 +343,11 @@ export class RelayRooms {
     if (!rawRoomId) {
       const minted = this.mintRoomCode();
       if (minted === null) {
-        this.sendError(conn, RelayErrorCodes.SERVER_BUSY, "Could not mint a room code");
+        this.sendError(
+          conn,
+          RelayErrorCodes.SERVER_BUSY,
+          "Could not mint a room code",
+        );
         return;
       }
       this.openRoom(conn, minted);
@@ -443,11 +461,74 @@ export class RelayRooms {
     }
   }
 
+  /**
+   * Host → many players in one frame: `payloads` maps a player's peer id to the
+   * payload meant for that player alone.
+   *
+   * This exists because a projected game (one where each phone sees a different
+   * view) otherwise sends one frame per player for every state change, and a
+   * relay bills — and rate-limits — per inbound frame. Fanning out here turns
+   * an N-player broadcast into a single inbound message.
+   *
+   * Players are delivered ordinary {@link RelayMessageTypes.DATA} frames, so
+   * nothing on the phone side knows this type exists and no client needs to be
+   * upgraded to benefit.
+   */
+  private routeMulti(
+    conn: RelayConnection,
+    payloads?: Record<string, string>,
+  ): void {
+    const mem = this.membership.get(conn.id);
+    if (!mem) {
+      this.sendError(conn, RelayErrorCodes.NOT_IN_ROOM, "Not in a room");
+      return;
+    }
+    // Only the host addresses players individually. A player reaching for this
+    // would be routing around the star topology to message the room directly.
+    if (mem.role !== "host") {
+      this.sendError(conn, RelayErrorCodes.MALFORMED, "Not the host");
+      return;
+    }
+    if (payloads === null || typeof payloads !== "object") {
+      this.sendError(conn, RelayErrorCodes.MALFORMED, "Missing payloads");
+      return;
+    }
+    const room = this.rooms.get(mem.roomId);
+    if (!room) return;
+
+    for (const [peerId, data] of Object.entries(payloads)) {
+      // A non-string payload is the one thing that would put malformed data on
+      // a phone's wire, since everything else here is opaque to us.
+      if (typeof data !== "string") {
+        this.sendError(
+          conn,
+          RelayErrorCodes.MALFORMED,
+          "Payload is not a string",
+        );
+        return;
+      }
+      // Unknown peer: skip, don't error. A projection built moments before a
+      // player left is routine, and the host already learns about the departure
+      // from PEER_LEFT.
+      const player = room.players.get(peerId);
+      if (!player) continue;
+      this.send(player, {
+        type: RelayMessageTypes.DATA,
+        roomId: mem.roomId,
+        data,
+      });
+    }
+  }
+
   private send(conn: RelayConnection, message: unknown): void {
     conn.send(JSON.stringify(message));
   }
 
-  private sendError(conn: RelayConnection, code: string, message: string): void {
+  private sendError(
+    conn: RelayConnection,
+    code: string,
+    message: string,
+  ): void {
     this.send(conn, { type: RelayMessageTypes.ERROR, code, message });
   }
 }

--- a/services/relay/tests/rooms.test.ts
+++ b/services/relay/tests/rooms.test.ts
@@ -330,6 +330,91 @@ describe("RelayRooms", () => {
   });
 });
 
+describe("DATA_MULTI", () => {
+  /** A room with a host and two joined players, each connection recording. */
+  function room() {
+    const rooms = new RelayRooms();
+    const host = conn("h");
+    const p1 = conn("p1");
+    const p2 = conn("p2");
+    rooms.handleMessage(host, JSON.stringify({ type: "CREATE_ROOM", roomId: "R" }));
+    rooms.handleMessage(p1, JSON.stringify({ type: "JOIN_ROOM", roomId: "R" }));
+    rooms.handleMessage(p2, JSON.stringify({ type: "JOIN_ROOM", roomId: "R" }));
+    host.sent.length = 0;
+    p1.sent.length = 0;
+    p2.sent.length = 0;
+    return { rooms, host, p1, p2 };
+  }
+
+  const multi = (payloads: unknown) =>
+    JSON.stringify({ type: RelayMessageTypes.DATA_MULTI, roomId: "R", payloads });
+
+  test("each player receives only its own payload, as a plain DATA frame", () => {
+    const { rooms, host, p1, p2 } = room();
+
+    rooms.handleMessage(host, multi({ p1: "one", p2: "two" }));
+
+    // Phones must not be able to tell this from a unicast DATA: that is what
+    // lets the batch ship without upgrading a single client.
+    expect(p1.sent).toEqual([{ type: RelayMessageTypes.DATA, roomId: "R", data: "one" }]);
+    expect(p2.sent).toEqual([{ type: RelayMessageTypes.DATA, roomId: "R", data: "two" }]);
+  });
+
+  test("counts as one message against the rate limit, not one per player", () => {
+    const rooms = new RelayRooms({ messagesPerWindow: 3, rateWindowMs: 1000 });
+    const host = conn("h");
+    rooms.handleMessage(host, JSON.stringify({ type: "CREATE_ROOM", roomId: "R" }));
+    for (const id of ["p1", "p2", "p3", "p4"]) {
+      rooms.handleMessage(conn(id), JSON.stringify({ type: "JOIN_ROOM", roomId: "R" }));
+    }
+
+    // Two four-player fan-outs would be 8 sends the old way, over the budget of
+    // 3; batched they are 2 messages. This saving is the point of the type.
+    const payloads = { p1: "a", p2: "a", p3: "a", p4: "a" };
+    expect(rooms.handleMessage(host, multi(payloads))).toBeNull();
+    expect(rooms.handleMessage(host, multi(payloads))).toBeNull();
+  });
+
+  test("unknown peer ids are skipped, not errors", () => {
+    const { rooms, host, p1 } = room();
+
+    // A projection built just before a player left is routine.
+    rooms.handleMessage(host, multi({ p1: "one", gone: "two" }));
+
+    expect(p1.sent).toHaveLength(1);
+    expect(host.sent).toEqual([]);
+  });
+
+  test("a player cannot address other players", () => {
+    const { rooms, p1, p2 } = room();
+
+    rooms.handleMessage(p1, multi({ p2: "spoofed" }));
+
+    expect(p2.sent).toEqual([]);
+    expect(p1.sent[0].code).toBe(RelayErrorCodes.MALFORMED);
+  });
+
+  test("missing or non-object payloads are rejected", () => {
+    const { rooms, host } = room();
+
+    rooms.handleMessage(host, JSON.stringify({ type: RelayMessageTypes.DATA_MULTI, roomId: "R" }));
+    expect(host.sent[0].code).toBe(RelayErrorCodes.MALFORMED);
+
+    host.sent.length = 0;
+    rooms.handleMessage(host, multi("not an object"));
+    expect(host.sent[0].code).toBe(RelayErrorCodes.MALFORMED);
+  });
+
+  test("a non-string payload is rejected rather than put on a phone's wire", () => {
+    const { rooms, host, p1 } = room();
+
+    rooms.handleMessage(host, multi({ p1: { nested: true } }));
+
+    expect(p1.sent).toEqual([]);
+    expect(host.sent[0].code).toBe(RelayErrorCodes.MALFORMED);
+  });
+});
+
 describe("room code case", () => {
   test("a room created upper-case is joinable lower-case", () => {
     // Codes are read off a TV and retyped or re-scanned on a phone; some


### PR DESCRIPTION
## Summary

Two independent cuts to relay traffic, both aimed at what a table actually costs
per hour on the free Cloudflare tier, where **inbound frames are the billed and
rate-limited unit**.

**1. Time-sync ping backs off (`feat(client)`)**

`useServerTime` pinged every 5s for the life of the connection. It now starts
there and doubles to a 30s ceiling, resetting on each new socket including
reconnects. The first pings converge the offset; after that it re-measures a
clock difference that does not drift. Four phones idling in a lobby went from
~5,760 relay messages/hour to under 1,000 — and pings are the *only* traffic an
untouched table generates.

`rtt` and `getServerTime()` keep their accuracy: same `PONG` handling, just less
often once settled.

**2. Projected updates batch into one frame (`feat(relay)`)**

A game with `project` sent one frame per player per state change, so a
four-player table paid 4 messages for one update and 4 of the display's
30/second budget. The cost grew with table size, and most of it isn't even
player-driven — domino's bot seats move every 600ms, card-game steps automatic
phases every 900ms.

- `GameRuntimeTransport` gains optional `sendMany(entries)`; transports without
  it (the LAN WebSocket path) are untouched.
- `RelayDisplayHost` implements it via a new host-only `DATA_MULTI` envelope
  (peer-id → payload map) that the relay unpacks into ordinary `DATA` frames.
- **Phones need no update** — nothing client-side can distinguish a batched
  update from a unicast one, which is what lets this ship without a flag day.
- The shared core means the Bun relay and the Durable Object get it identically.

Two edges worth a reviewer's eye:

| | |
|---|---|
| **Size** | N views in one envelope is N× the bytes. A batch over the 256KB ceiling falls back to individual frames — splitting costs messages, being dropped costs the game. |
| **Trust** | `DATA_MULTI` from a phone is rejected. Unpacking it for a player would hand them a way to message another phone directly, around the star topology the relay exists to enforce. |

Together these take a 4-player domino table from ~9,400 messages/table-hour to
~2,400 — roughly 210 → 830 free table-hours/day.

## Related issues

_None._

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation only
- [ ] Chore / tooling / CI

## Checklist

- [x] I read the [Contributing guide](../CONTRIBUTING.md).
- [x] Changes use **Bun** only (no npm/yarn/pnpm).
- [x] `bun run test`, `bun run typecheck`, and `bun run build` pass locally.
- [x] Tests were added or updated for the change (coverage floors in `bun run coverage` still hold).
- [x] A changeset is included for any change to published `packages/*` source (`bun run changeset`). Workflow/config/docs-only changes do not need one.
- [x] I did **not** edit `CHANGELOG.md` files or `workspace:*` references by hand.

## Notes for reviewers

**Deploy ordering is handled by the merge itself, but worth confirming.** An
older relay answers `DATA_MULTI` with `MALFORMED`, so relays must lead. Merging
this deploys `services/relay-worker` immediately via Workers Builds, while
`@couch-kit/display` only reaches consumers after the Version Packages PR
merges and the games bump — so the relay is always ahead. If that assumption is
wrong for any deployment I don't know about, this should be split into two PRs
with the relay landing first.

Verified locally: all 7 packages + `services/relay` (40 tests) green,
`typecheck` clean including `services/relay-worker`'s `tsc --noEmit`, coverage
floors hold (runtime 99.65%, display 98.06%).

The existing `relay-protocol-contract.test.ts` already guards client/relay
constant drift and covers `DATA_MULTI` for free.

New tests worth reading: the relay's rate-limit test asserts the actual saving
(two 4-player fan-outs fit in a 3-message budget), and the display's fallback
test asserts a batch too large splits rather than gets dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
